### PR TITLE
don't require full module path in qualifiers

### DIFF
--- a/src/compose/error.rs
+++ b/src/compose/error.rs
@@ -92,6 +92,8 @@ pub enum ComposerErrorInner {
     InconsistentShaderDefValue { def: String },
     #[error("Attempted to add a module with no #define_import_path")]
     NoModuleName,
+    #[error("Duplicated import name: `{name}`")]
+    DuplicateImportName { pos: usize, name: String },
     #[error("source contains internal decoration string, results probably won't be what you expect. if you have a legitimate reason to do this please file a report")]
     DecorationInSource(Range<usize>),
     #[error("naga oil only supports glsl 440 and 450")]
@@ -190,6 +192,10 @@ impl ComposerError {
             ComposerErrorInner::ImportNotFound(msg, pos) => (
                 vec![Label::primary((), *pos..*pos)],
                 vec![format!("missing import '{msg}'")],
+            ),
+            ComposerErrorInner::DuplicateImportName { name, pos } => (
+                vec![Label::primary((), *pos..*pos)],
+                vec![format!("duplicate import '{name}'")],
             ),
             ComposerErrorInner::WgslParseError(e) => (
                 e.labels()

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -453,14 +453,20 @@ impl Composer {
                 // check for duplicates
                 if let Some(&prior) = as_names.get(import.definition.as_name()) {
                     if prior != import.definition.import.as_str() {
-                        return Err(ComposerErrorInner::DuplicateImportName { pos: import.offset, name: import.definition.as_name().to_owned() });
+                        return Err(ComposerErrorInner::DuplicateImportName {
+                            pos: import.offset,
+                            name: import.definition.as_name().to_owned(),
+                        });
                     }
                 }
-                as_names.insert(import.definition.as_name(), import.definition.import.as_str());
+                as_names.insert(
+                    import.definition.as_name(),
+                    import.definition.import.as_str(),
+                );
                 Ok(import.definition.as_import_ref())
             })
             .collect::<Result<Vec<ImportRef>, ComposerErrorInner>>()?;
-        
+
         // add short-form module name if required (`pbr_bindings` if the name is `bevy_pbr::pbr_bindings`)
         for import in imports.iter() {
             if import.definition.as_name.is_none()
@@ -476,7 +482,10 @@ impl Composer {
                     .1;
 
                 // ensure it's not already being used
-                if import_data.iter().any(|prior_import| prior_import.as_name == as_name && prior_import.import != import.definition.import ) {
+                if import_data.iter().any(|prior_import| {
+                    prior_import.as_name == as_name
+                        && prior_import.import != import.definition.import
+                }) {
                     return Err(ComposerErrorInner::DuplicateImportName {
                         pos: import.offset,
                         name: as_name.to_owned(),

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -968,6 +968,39 @@ mod test {
         output_eq!(wgsl, "tests/expected/dup_struct_import.txt");
     }
 
+    #[test]
+    fn test_duplicate_import_name() {
+        let mut composer = Composer::default();
+
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/dup_import_name/import_a.wgsl"),
+                file_path: "tests/dup_import_name/import_a.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/dup_import_name/import_b.wgsl"),
+                file_path: "tests/dup_import_name/import_b.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        let error = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/dup_import_name/top.wgsl"),
+                file_path: "tests/dup_import_name/top.wgsl",
+                ..Default::default()
+            })
+            .err()
+            .unwrap();
+
+        let text = error.emit_to_string(&composer);
+
+        output_eq!(text, "tests/expected/dup_import_name.txt")
+    }
+
     // actually run a shader and extract the result
     // needs the composer to contain a module called "test_module", with a function called "entry_point" returning an f32.
     fn test_shader(composer: &mut Composer) -> f32 {

--- a/src/compose/tests/dup_import_name/import_a.wgsl
+++ b/src/compose/tests/dup_import_name/import_a.wgsl
@@ -1,0 +1,3 @@
+#define_import_path path_a::import
+
+const a: u32 = 1u;

--- a/src/compose/tests/dup_import_name/import_b.wgsl
+++ b/src/compose/tests/dup_import_name/import_b.wgsl
@@ -1,0 +1,3 @@
+#define_import_path path_b::import
+
+const b: u32 = 1u;

--- a/src/compose/tests/dup_import_name/top.wgsl
+++ b/src/compose/tests/dup_import_name/top.wgsl
@@ -1,0 +1,6 @@
+#import path_a::import
+#import path_b::import
+
+fn main() -> u32 {
+    return 1u;
+} 

--- a/src/compose/tests/expected/dup_import_name.txt
+++ b/src/compose/tests/expected/dup_import_name.txt
@@ -1,0 +1,8 @@
+error: Duplicated import name: `import`
+  ┌─ tests/dup_import_name/top.wgsl:1:24
+  │
+1 │ #import path_a::import
+  │                        
+  │
+  = duplicate import 'import'
+


### PR DESCRIPTION
allow module name qualifiers for imported items without module path:

```
#import bevy_pbr::pbr_types
fn shade(in: bevy_pbr::pbr_types::StandardMaterial) { .. }
```
->
```
#import bevy_pbr::pbr_types
fn shade(in: pbr_types::StandardMaterial) { .. }
```

this also adds a new error, `DuplicateImportName` which should only kick in when two or more imports are given the same name (directly or indirectly) but don't refer to the same module. previously we would silently use the first defined name. duplicate imports referring to the same module are accepted (there are some in the bevy code base).

i have only briefly spot-checked bevy examples.