### PR TITLE
Auto import fully qualified identifiers

### DIFF
--- a/implicit_import.txt
+++ b/implicit_import.txt
@@ -1,0 +1,6 @@
+const _naga_oil_mod_NVXWI_memberc: u32 = 1u;
+
+fn main() -> u32 {
+    return _naga_oil_mod_NVXWI_memberc;
+}
+

--- a/src/compose/error.rs
+++ b/src/compose/error.rs
@@ -92,6 +92,8 @@ pub enum ComposerErrorInner {
     InconsistentShaderDefValue { def: String },
     #[error("Attempted to add a module with no #define_import_path")]
     NoModuleName,
+    #[error("Duplicated import name: `{name}`")]
+    DuplicateImportName { pos: usize, name: String },
     #[error("source contains internal decoration string, results probably won't be what you expect. if you have a legitimate reason to do this please file a report")]
     DecorationInSource(Range<usize>),
     #[error("naga oil only supports glsl 440 and 450")]
@@ -190,6 +192,10 @@ impl ComposerError {
             ComposerErrorInner::ImportNotFound(msg, pos) => (
                 vec![Label::primary((), *pos..*pos)],
                 vec![format!("missing import '{msg}'")],
+            ),
+            ComposerErrorInner::DuplicateImportName { name, pos } => (
+                vec![Label::primary((), *pos..*pos)],
+                vec![format!("duplicate import '{name}'")],
             ),
             ComposerErrorInner::WgslParseError(e) => (
                 e.labels()

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -453,14 +453,20 @@ impl Composer {
                 // check for duplicates
                 if let Some(&prior) = as_names.get(import.definition.as_name()) {
                     if prior != import.definition.import.as_str() {
-                        return Err(ComposerErrorInner::DuplicateImportName { pos: import.offset, name: import.definition.as_name().to_owned() });
+                        return Err(ComposerErrorInner::DuplicateImportName {
+                            pos: import.offset,
+                            name: import.definition.as_name().to_owned(),
+                        });
                     }
                 }
-                as_names.insert(import.definition.as_name(), import.definition.import.as_str());
+                as_names.insert(
+                    import.definition.as_name(),
+                    import.definition.import.as_str(),
+                );
                 Ok(import.definition.as_import_ref())
             })
             .collect::<Result<Vec<ImportRef>, ComposerErrorInner>>()?;
-        
+
         // add short-form module name if required (`pbr_bindings` if the name is `bevy_pbr::pbr_bindings`)
         for import in imports.iter() {
             if import.definition.as_name.is_none()
@@ -476,7 +482,10 @@ impl Composer {
                     .1;
 
                 // ensure it's not already being used
-                if import_data.iter().any(|prior_import| prior_import.as_name == as_name && prior_import.import != import.definition.import ) {
+                if import_data.iter().any(|prior_import| {
+                    prior_import.as_name == as_name
+                        && prior_import.import != import.definition.import
+                }) {
                     return Err(ComposerErrorInner::DuplicateImportName {
                         pos: import.offset,
                         name: as_name.to_owned(),

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -506,24 +506,21 @@ impl Composer {
         let mut imported_items = HashMap::new();
 
         for import in import_data {
-            match import.items {
-                Some(items) => {
-                    // gather individual imported items
-                    for item in items {
-                        imported_items.insert(
-                            item.clone(),
-                            format!("{}{}", Self::decorate(import.import), item),
-                        );
-                    }
-                }
-                None => {
-                    // replace the module name directly
-                    substituted_source = substituted_source.replace(
-                        format!("{}::", import.as_name).as_str(),
-                        &Self::decorate(import.import),
+            if let Some(items) = import.items {
+                // gather individual imported items
+                for item in items {
+                    imported_items.insert(
+                        item.clone(),
+                        format!("{}{}", Self::decorate(import.import), item),
                     );
                 }
             }
+
+            // replace the module name directly
+            substituted_source = substituted_source.replace(
+                format!("{}::", import.as_name).as_str(),
+                &Self::decorate(import.import),
+            );
         }
 
         // map individually imported items

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -968,6 +968,39 @@ mod test {
         output_eq!(wgsl, "tests/expected/dup_struct_import.txt");
     }
 
+    #[test]
+    fn test_duplicate_import_name() {
+        let mut composer = Composer::default();
+
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/dup_import_name/import_a.wgsl"),
+                file_path: "tests/dup_import_name/import_a.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/dup_import_name/import_b.wgsl"),
+                file_path: "tests/dup_import_name/import_b.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        let error = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/dup_import_name/top.wgsl"),
+                file_path: "tests/dup_import_name/top.wgsl",
+                ..Default::default()
+            })
+            .err()
+            .unwrap();
+
+        let text = error.emit_to_string(&composer);
+
+        output_eq!(text, "tests/expected/dup_import_name.txt")
+    }
+
     // actually run a shader and extract the result
     // needs the composer to contain a module called "test_module", with a function called "entry_point" returning an f32.
     fn test_shader(composer: &mut Composer) -> f32 {

--- a/src/compose/tests/dup_import_name/import_a.wgsl
+++ b/src/compose/tests/dup_import_name/import_a.wgsl
@@ -1,0 +1,3 @@
+#define_import_path path_a::import
+
+const a: u32 = 1u;

--- a/src/compose/tests/dup_import_name/import_b.wgsl
+++ b/src/compose/tests/dup_import_name/import_b.wgsl
@@ -1,0 +1,3 @@
+#define_import_path path_b::import
+
+const b: u32 = 1u;

--- a/src/compose/tests/dup_import_name/top.wgsl
+++ b/src/compose/tests/dup_import_name/top.wgsl
@@ -1,0 +1,6 @@
+#import path_a::import
+#import path_b::import
+
+fn main() -> u32 {
+    return 1u;
+} 

--- a/src/compose/tests/expected/dup_import_name.txt
+++ b/src/compose/tests/expected/dup_import_name.txt
@@ -1,0 +1,8 @@
+error: Duplicated import name: `import`
+  ┌─ tests/dup_import_name/top.wgsl:1:24
+  │
+1 │ #import path_a::import
+  │                        
+  │
+  = duplicate import 'import'
+

--- a/src/compose/tests/expected/implicit_import.txt
+++ b/src/compose/tests/expected/implicit_import.txt
@@ -1,0 +1,6 @@
+const _naga_oil_mod_NVXWI_memberc: u32 = 1u;
+
+fn main() -> u32 {
+    return _naga_oil_mod_NVXWI_memberc;
+}
+

--- a/src/compose/tests/expected/implicit_import_fail.txt
+++ b/src/compose/tests/expected/implicit_import_fail.txt
@@ -1,0 +1,8 @@
+error: required import 'mod' not found
+  ┌─ tests/implicit_import/top.wgsl:2:12
+  │
+2 │     return mod::c;
+  │            ^
+  │
+  = missing import 'mod'
+

--- a/src/compose/tests/implicit_import/mod.wgsl
+++ b/src/compose/tests/implicit_import/mod.wgsl
@@ -1,0 +1,3 @@
+#define_import_path mod
+
+const c: u32 = 1u;

--- a/src/compose/tests/implicit_import/top.wgsl
+++ b/src/compose/tests/implicit_import/top.wgsl
@@ -1,0 +1,3 @@
+fn main() -> u32 {
+    return mod::c;
+}


### PR DESCRIPTION
builds on #24. allows use of fully qualified items without an explicit import statement

```
#import bevy_pbr::pbr_types

fn main(in: pbr_types::StandardMaterial) { .. }
```
->
```
fn main(in: bevy_pbr::pbr_types::StandardMaterial) { .. }
```

this is quite ugly. scanning the file requires comment state tracking (wgsl /* allows /* nested */ block */ comments), there's quite a lot of duplicated code between the two main preprocessor functions which should be refactored, and it needs some tests for the comment tracking functionality, but i'm out of time for now.

spot-checked on bevy codebase again. 

also noting that i'm pretty sure both this and #24 are non-breaking (they will only allow code that would previously fail) so could be released separately to bevy itself.