### PR TITLE
substitute after preprocessing

### DIFF
--- a/src/compose/error.rs
+++ b/src/compose/error.rs
@@ -39,7 +39,7 @@ impl ErrSource {
     pub fn source<'a>(&'a self, composer: &'a Composer) -> Cow<'a, String> {
         match self {
             ErrSource::Module { name, defs, .. } => {
-                let raw_source = &composer.module_sets.get(name).unwrap().raw_source;
+                let raw_source = &composer.module_sets.get(name).unwrap().sanitized_source;
                 let Ok(PreprocessOutput {
                     preprocessed_source: source,
                     meta: PreprocessorMetaData { imports, .. },
@@ -51,7 +51,7 @@ impl ErrSource {
                     };
 
                 let Ok(source) = composer
-                    .sanitize_and_substitute_shader_string(&source, &imports)
+                    .substitute_shader_string(&source, &imports)
                     else { return Default::default() };
 
                 Cow::Owned(source)

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -1542,7 +1542,7 @@ impl Composer {
                     ),
                     source: ErrSource::Constructing {
                         path: file_path.to_owned(),
-                        source: substituted_source.clone(),
+                        source: source.to_owned(),
                         offset: 0,
                     },
                 })?;

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -1534,8 +1534,6 @@ impl Composer {
                 }),
         );
 
-        let substituted_source = self.sanitize_and_set_auto_bindings(source);
-
         let mut effective_defs = HashSet::new();
         for import in &imports {
             // we require modules already added so that we can capture the shader_defs that may impact us by impacting our dependencies

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -968,6 +968,81 @@ mod test {
         output_eq!(wgsl, "tests/expected/dup_struct_import.txt");
     }
 
+    #[test]
+    fn conditional_import() {
+        let mut composer = Composer::default();
+
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/conditional_import/mod_a.wgsl"),
+                file_path: "tests/conditional_import/mod_a.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/conditional_import/mod_b.wgsl"),
+                file_path: "tests/conditional_import/mod_b.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        let module_a = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/conditional_import/top.wgsl"),
+                file_path: "tests/conditional_import/top.wgsl",
+                shader_defs: HashMap::from_iter([("USE_A".to_owned(), ShaderDefValue::Bool(true))]),
+                ..Default::default()
+            })
+            .unwrap();
+
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::default(),
+        )
+        .validate(&module_a)
+        .unwrap();
+        let wgsl = naga::back::wgsl::write_string(
+            &module_a,
+            &info,
+            naga::back::wgsl::WriterFlags::EXPLICIT_TYPES,
+        )
+        .unwrap();
+
+        // let mut f = std::fs::File::create("conditional_import_a.txt").unwrap();
+        // f.write_all(wgsl.as_bytes()).unwrap();
+        // drop(f);
+
+        output_eq!(wgsl, "tests/expected/conditional_import_a.txt");
+
+        let module_b = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/conditional_import/top.wgsl"),
+                file_path: "tests/conditional_import/top.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::default(),
+        )
+        .validate(&module_b)
+        .unwrap();
+        let wgsl = naga::back::wgsl::write_string(
+            &module_b,
+            &info,
+            naga::back::wgsl::WriterFlags::EXPLICIT_TYPES,
+        )
+        .unwrap();
+
+        // let mut f = std::fs::File::create("conditional_import_b.txt").unwrap();
+        // f.write_all(wgsl.as_bytes()).unwrap();
+        // drop(f);
+
+        output_eq!(wgsl, "tests/expected/conditional_import_b.txt");
+    }
+
     // actually run a shader and extract the result
     // needs the composer to contain a module called "test_module", with a function called "entry_point" returning an f32.
     fn test_shader(composer: &mut Composer) -> f32 {

--- a/src/compose/tests/conditional_import/mod_a.wgsl
+++ b/src/compose/tests/conditional_import/mod_a.wgsl
@@ -1,0 +1,3 @@
+#define_import_path a
+
+const C: u32 = 1u;

--- a/src/compose/tests/conditional_import/mod_b.wgsl
+++ b/src/compose/tests/conditional_import/mod_b.wgsl
@@ -1,0 +1,3 @@
+#define_import_path b
+
+const C: u32 = 2u;

--- a/src/compose/tests/conditional_import/top.wgsl
+++ b/src/compose/tests/conditional_import/top.wgsl
@@ -1,0 +1,9 @@
+#ifdef USE_A
+    #import a C
+#else
+    #import b C
+#endif
+
+fn main() -> u32 {
+    return C;
+}

--- a/src/compose/tests/expected/conditional_import_a.txt
+++ b/src/compose/tests/expected/conditional_import_a.txt
@@ -1,0 +1,6 @@
+const _naga_oil_mod_ME_memberC: u32 = 1u;
+
+fn main() -> u32 {
+    return _naga_oil_mod_ME_memberC;
+}
+

--- a/src/compose/tests/expected/conditional_import_b.txt
+++ b/src/compose/tests/expected/conditional_import_b.txt
@@ -1,0 +1,6 @@
+const _naga_oil_mod_MI_memberC: u32 = 2u;
+
+fn main() -> u32 {
+    return _naga_oil_mod_MI_memberC;
+}
+


### PR DESCRIPTION
fixes #27

perform module and item substitution after preprocessing to make sure we use the right imports. 

this is a breaking change as we need to add shader defs into the public `ErrSource::Module` variant, so that errors can be reported with the correct substitutions.