### PR TITLE
handle comments

### DIFF
--- a/src/compose/comment_strip_iter.rs
+++ b/src/compose/comment_strip_iter.rs
@@ -1,0 +1,146 @@
+use std::{borrow::Cow, str::Lines};
+
+use regex::Regex;
+
+static RE_COMMENT: once_cell::sync::Lazy<Regex> =
+    once_cell::sync::Lazy::new(|| Regex::new(r"(\/\/|\/\*|\*\/)").unwrap());
+
+pub struct CommentReplaceIter<'a> {
+    lines: &'a mut Lines<'a>,
+    block_depth: usize,
+}
+
+impl<'a> Iterator for CommentReplaceIter<'a> {
+    type Item = Cow<'a, str>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let line_in = self.lines.next()?;
+        let mut markers = RE_COMMENT
+            .captures_iter(line_in)
+            .map(|cap| cap.get(0).unwrap())
+            .peekable();
+
+        // fast path
+        if self.block_depth == 0 && markers.peek().is_none() {
+            return Some(Cow::Borrowed(line_in));
+        }
+
+        let mut output = String::new();
+        let mut section_start = 0;
+
+        loop {
+            let mut next_marker = markers.next();
+            let mut section_end = next_marker.map(|m| m.start()).unwrap_or(line_in.len());
+
+            // skip partial tokens
+            while next_marker.is_some() && section_start > section_end {
+                next_marker = markers.next();
+                section_end = next_marker.map(|m| m.start()).unwrap_or(line_in.len());
+            }
+
+            if self.block_depth == 0 {
+                output.push_str(&line_in[section_start..section_end]);
+            } else {
+                output.extend(std::iter::repeat(' ').take(section_end - section_start));
+            }
+
+            match next_marker {
+                None => return Some(Cow::Owned(output)),
+                Some(marker) => {
+                    match marker.as_str() {
+                        "//" => {
+                            // the specs (https://www.w3.org/TR/WGSL/#comment, https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.pdf @ 3.4) state that
+                            // whichever comment-type starts first should cancel parsing of the other type
+                            if self.block_depth == 0 {
+                                output.extend(
+                                    std::iter::repeat(' ').take(line_in.len() - marker.start()),
+                                );
+                                return Some(Cow::Owned(output));
+                            }
+                        }
+                        "/*" => {
+                            self.block_depth += 1;
+                        }
+                        "*/" => {
+                            self.block_depth = self.block_depth.saturating_sub(1);
+                        }
+                        _ => unreachable!(),
+                    }
+                    output.extend(std::iter::repeat(' ').take(marker.as_str().len()));
+                    section_start = marker.end();
+                }
+            }
+        }
+    }
+}
+
+pub trait CommentReplaceExt<'a> {
+    /// replace WGSL and GLSL comments with whitespace characters
+    fn replace_comments(&'a mut self) -> CommentReplaceIter;
+}
+
+impl<'a> CommentReplaceExt<'a> for Lines<'a> {
+    fn replace_comments(&'a mut self) -> CommentReplaceIter {
+        CommentReplaceIter {
+            lines: self,
+            block_depth: 0,
+        }
+    }
+}
+
+#[test]
+fn comment_test() {
+    const INPUT: &str = r"
+not commented
+// line commented
+not commented
+/* block commented on a line */
+not commented
+// line comment with a /* block comment unterminated
+not commented
+/* block comment
+   spanning lines */
+not commented
+/* block comment
+   spanning lines and with // line comments
+   even with a // line commented terminator */
+not commented
+";
+
+    assert_eq!(
+        INPUT
+            .lines()
+            .replace_comments()
+            .zip(INPUT.lines())
+            .find(|(line, original)| {
+                (line != "not commented" && !line.chars().all(|c| c == ' '))
+                    || line.len() != original.len()
+            }),
+        None
+    );
+
+    const PARTIAL_TESTS: [(&str, &str); 4] = [
+        (
+            "1.0 /* block comment with a partial line comment on the end *// 2.0",
+            "1.0                                                           / 2.0",
+        ),
+        (
+            "1.0 /* block comment with a partial block comment on the end */* 2.0",
+            "1.0                                                            * 2.0",
+        ),
+        (
+            "1.0 /* block comment 1 *//* block comment 2 */ * 2.0",
+            "1.0                                            * 2.0",
+        ),
+        (
+            "1.0 /* block comment with real line comment after */// line comment",
+            "1.0                                                                ",
+        ),
+    ];
+
+    for &(input, expected) in PARTIAL_TESTS.iter() {
+        let mut nasty_processed = input.lines();
+        let nasty_processed = nasty_processed.replace_comments().next().unwrap();
+        assert_eq!(&nasty_processed, expected);
+    }
+}

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -139,6 +139,7 @@ use crate::{
 pub use self::error::{ComposerError, ComposerErrorInner, ErrSource};
 use self::preprocess::Preprocessor;
 
+pub mod comment_strip_iter;
 pub mod error;
 pub mod preprocess;
 mod test;

--- a/src/compose/preprocess.rs
+++ b/src/compose/preprocess.rs
@@ -3,7 +3,10 @@ use std::collections::{HashMap, HashSet};
 use regex::Regex;
 use tracing::warn;
 
-use super::{ComposerErrorInner, ImportDefWithOffset, ImportDefinition, ShaderDefValue};
+use super::{
+    comment_strip_iter::CommentReplaceExt, ComposerErrorInner, ImportDefWithOffset,
+    ImportDefinition, ShaderDefValue,
+};
 
 #[derive(Debug)]
 pub struct Preprocessor {
@@ -159,7 +162,13 @@ impl Preprocessor {
         let len = shader_str.len();
 
         // this code broadly stolen from bevy_render::ShaderProcessor
-        for line in shader_str.lines() {
+        for (line, original_line) in shader_str
+            .lines()
+            .replace_comments()
+            .zip(shader_str.lines())
+        {
+            let line = &line;
+
             let mut output = false;
             let mut still_at_start = false;
             if line.is_empty() {
@@ -321,7 +330,7 @@ impl Preprocessor {
                         offset,
                     });
                 } else {
-                    let mut line_with_defs = line.to_string();
+                    let mut line_with_defs = original_line.to_string();
                     for capture in self.def_regex.captures_iter(line) {
                         let def = capture.get(1).unwrap();
                         if let Some(def) = shader_defs.get(def.as_str()) {
@@ -388,7 +397,8 @@ impl Preprocessor {
         let mut offset = 0;
         let mut defines = HashMap::default();
 
-        for line in shader_str.lines() {
+        for line in shader_str.lines().replace_comments() {
+            let line = &line;
             if let Some(cap) = self.import_custom_path_as_regex.captures(line) {
                 imports.push(ImportDefWithOffset {
                     definition: ImportDefinition {
@@ -457,12 +467,12 @@ impl Preprocessor {
     pub fn effective_defs(&self, source: &str) -> HashSet<String> {
         let mut effective_defs = HashSet::default();
 
-        for line in source.lines() {
-            if let Some(cap) = self.ifdef_regex.captures(line) {
+        for line in source.lines().replace_comments() {
+            if let Some(cap) = self.ifdef_regex.captures(&line) {
                 let def = cap.get(2).unwrap();
                 effective_defs.insert(def.as_str().to_owned());
             }
-            if let Some(cap) = self.ifndef_regex.captures(line) {
+            if let Some(cap) = self.ifndef_regex.captures(&line) {
                 let def = cap.get(2).unwrap();
                 effective_defs.insert(def.as_str().to_owned());
             }

--- a/src/compose/preprocess.rs
+++ b/src/compose/preprocess.rs
@@ -171,7 +171,7 @@ impl Preprocessor {
 
             let mut output = false;
             let mut still_at_start = false;
-            if line.is_empty() {
+            if line.is_empty() || line.chars().all(|c| c.is_ascii_whitespace()) {
                 still_at_start = true;
             }
 


### PR DESCRIPTION
adds comment handling to the preprocessor. fixes #34 and lays groundwork for #25. separated out mainly because it is easier to review as a smaller piece and less risky than #25.

luckily glsl and wgsl use the same comment spec