### PR TITLE
migrate to naga 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ prune = []
 override_any = []
 
 [dependencies]
-naga = { version="0.12", features = ["wgsl-in", "wgsl-out", "glsl-in", "glsl-out", "clone", "span"] }
+naga = { version="0.13", features = ["wgsl-in", "wgsl-out", "glsl-in", "glsl-out", "clone", "span"] }
 tracing = "0.1"
 regex = "1.5"
 regex-syntax = "0.6"
@@ -29,6 +29,6 @@ once_cell = "1.17.0"
 indexmap = "1.9.3"
 
 [dev-dependencies]
-wgpu = { version = "0.16", features=["naga"] }
+wgpu = { version = "0.17", features=["naga"] }
 futures-lite = "1"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga_oil"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "a crate for combining and manipulating shaders using naga IR"

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -143,6 +143,7 @@ pub mod comment_strip_iter;
 pub mod error;
 pub mod preprocess;
 mod test;
+pub mod util;
 
 #[derive(Hash, PartialEq, Eq, Clone, Copy, Debug, Default)]
 pub enum ShaderLanguage {

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -1083,6 +1083,45 @@ mod test {
         output_eq!(wgsl, "tests/expected/conditional_import_b.txt");
     }
 
+    #[test]
+    fn use_shared_global() {
+        let mut composer = Composer::default();
+
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/use_shared_global/mod.wgsl"),
+                file_path: "tests/use_shared_global/mod.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+        let module = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/use_shared_global/top.wgsl"),
+                file_path: "tests/use_shared_global/top.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::default(),
+        )
+        .validate(&module)
+        .unwrap();
+        let wgsl = naga::back::wgsl::write_string(
+            &module,
+            &info,
+            naga::back::wgsl::WriterFlags::EXPLICIT_TYPES,
+        )
+        .unwrap();
+
+        // let mut f = std::fs::File::create("use_shared_global.txt").unwrap();
+        // f.write_all(wgsl.as_bytes()).unwrap();
+        // drop(f);
+
+        output_eq!(wgsl, "tests/expected/use_shared_global.txt");
+    }
+
     // actually run a shader and extract the result
     // needs the composer to contain a module called "test_module", with a function called "entry_point" returning an f32.
     fn test_shader(composer: &mut Composer) -> f32 {

--- a/src/compose/tests/expected/dup_import.txt
+++ b/src/compose/tests/expected/dup_import.txt
@@ -1,4 +1,4 @@
-const _naga_oil_mod_MNXW443UOM_memberPI: f32 = 3.0999999046325684;
+const _naga_oil_mod_MNXW443UOM_memberPI: f32 = 3.1;
 
 fn _naga_oil_mod_ME_memberf() -> f32 {
     return (_naga_oil_mod_MNXW443UOM_memberPI * 1.0);

--- a/src/compose/tests/expected/import_in_decl.txt
+++ b/src/compose/tests/expected/import_in_decl.txt
@@ -1,8 +1,7 @@
 const _naga_oil_mod_MNXW443UOM_memberX: u32 = 1u;
-
 const _naga_oil_mod_MJUW4ZA_membery: u32 = 2u;
 
-var<private> _naga_oil_mod_MJUW4ZA_memberarr: array<u32,_naga_oil_mod_MNXW443UOM_memberX>;
+var<private> _naga_oil_mod_MJUW4ZA_memberarr: array<u32, 1>;
 
 fn main() -> f32 {
     let _e2: u32 = _naga_oil_mod_MJUW4ZA_memberarr[0];

--- a/src/compose/tests/expected/item_import_test.txt
+++ b/src/compose/tests/expected/item_import_test.txt
@@ -2,7 +2,6 @@
 
 
 
-
     let _e1: u32 = _naga_oil_mod_MNXW443UOM_memberdouble(_naga_oil_mod_MNXW443UOM_memberX);
     let _e1: u32 = _naga_oil_mod_MNXW443UOM_memberdouble(_naga_oil_mod_MNXW443UOM_memberY);
     return (in * 2u);

--- a/src/compose/tests/expected/use_shared_global.txt
+++ b/src/compose/tests/expected/use_shared_global.txt
@@ -1,0 +1,15 @@
+var<private> _naga_oil_mod_NVXWI_membera: f32 = 0.0;
+
+fn add() {
+    let _e2: f32 = _naga_oil_mod_NVXWI_membera;
+    _naga_oil_mod_NVXWI_membera = (_e2 + 1.0);
+    return;
+}
+
+fn main() -> f32 {
+    add();
+    add();
+    let _e1: f32 = _naga_oil_mod_NVXWI_membera;
+    return _e1;
+}
+

--- a/src/compose/tests/use_shared_global/mod.wgsl
+++ b/src/compose/tests/use_shared_global/mod.wgsl
@@ -1,0 +1,3 @@
+#define_import_path mod
+
+var<private> a: f32 = 0.0;

--- a/src/compose/tests/use_shared_global/top.wgsl
+++ b/src/compose/tests/use_shared_global/top.wgsl
@@ -1,0 +1,11 @@
+#import mod
+
+fn add() {
+    mod::a += 1.0;
+}
+
+fn main() -> f32 {
+    add();
+    add();
+    return mod::a;
+}

--- a/src/compose/util.rs
+++ b/src/compose/util.rs
@@ -1,0 +1,267 @@
+use naga::Expression;
+
+// Expression does not implement PartialEq except for internal testing (cfg_attr(test)), so we must use our own version.
+// This implementation is tweaked from the output of `cargo expand`
+#[inline]
+pub fn expression_eq(lhs: &Expression, rhs: &Expression) -> bool {
+    let __lhs_tag = std::mem::discriminant(lhs);
+    let __arg1_tag = std::mem::discriminant(rhs);
+    __lhs_tag == __arg1_tag
+        && match (lhs, rhs) {
+            (Expression::Literal(__lhs_0), Expression::Literal(__arg1_0)) => *__lhs_0 == *__arg1_0,
+            (Expression::Constant(__lhs_0), Expression::Constant(__arg1_0)) => {
+                *__lhs_0 == *__arg1_0
+            }
+            (Expression::ZeroValue(__lhs_0), Expression::ZeroValue(__arg1_0)) => {
+                *__lhs_0 == *__arg1_0
+            }
+            (
+                Expression::Compose {
+                    ty: __lhs_0,
+                    components: __lhs_1,
+                },
+                Expression::Compose {
+                    ty: __arg1_0,
+                    components: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            (
+                Expression::Access {
+                    base: __lhs_0,
+                    index: __lhs_1,
+                },
+                Expression::Access {
+                    base: __arg1_0,
+                    index: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            (
+                Expression::AccessIndex {
+                    base: __lhs_0,
+                    index: __lhs_1,
+                },
+                Expression::AccessIndex {
+                    base: __arg1_0,
+                    index: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            (
+                Expression::Splat {
+                    size: __lhs_0,
+                    value: __lhs_1,
+                },
+                Expression::Splat {
+                    size: __arg1_0,
+                    value: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            (
+                Expression::Swizzle {
+                    size: __lhs_0,
+                    vector: __lhs_1,
+                    pattern: __lhs_2,
+                },
+                Expression::Swizzle {
+                    size: __arg1_0,
+                    vector: __arg1_1,
+                    pattern: __arg1_2,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1 && *__lhs_2 == *__arg1_2,
+            (Expression::FunctionArgument(__lhs_0), Expression::FunctionArgument(__arg1_0)) => {
+                *__lhs_0 == *__arg1_0
+            }
+            (Expression::GlobalVariable(__lhs_0), Expression::GlobalVariable(__arg1_0)) => {
+                *__lhs_0 == *__arg1_0
+            }
+            (Expression::LocalVariable(__lhs_0), Expression::LocalVariable(__arg1_0)) => {
+                *__lhs_0 == *__arg1_0
+            }
+            (Expression::Load { pointer: __lhs_0 }, Expression::Load { pointer: __arg1_0 }) => {
+                *__lhs_0 == *__arg1_0
+            }
+            (
+                Expression::ImageSample {
+                    image: __lhs_0,
+                    sampler: __lhs_1,
+                    gather: __lhs_2,
+                    coordinate: __lhs_3,
+                    array_index: __lhs_4,
+                    offset: __lhs_5,
+                    level: __lhs_6,
+                    depth_ref: __lhs_7,
+                },
+                Expression::ImageSample {
+                    image: __arg1_0,
+                    sampler: __arg1_1,
+                    gather: __arg1_2,
+                    coordinate: __arg1_3,
+                    array_index: __arg1_4,
+                    offset: __arg1_5,
+                    level: __arg1_6,
+                    depth_ref: __arg1_7,
+                },
+            ) => {
+                *__lhs_0 == *__arg1_0
+                    && *__lhs_1 == *__arg1_1
+                    && *__lhs_2 == *__arg1_2
+                    && *__lhs_3 == *__arg1_3
+                    && *__lhs_4 == *__arg1_4
+                    && *__lhs_5 == *__arg1_5
+                    && *__lhs_6 == *__arg1_6
+                    && *__lhs_7 == *__arg1_7
+            }
+            (
+                Expression::ImageLoad {
+                    image: __lhs_0,
+                    coordinate: __lhs_1,
+                    array_index: __lhs_2,
+                    sample: __lhs_3,
+                    level: __lhs_4,
+                },
+                Expression::ImageLoad {
+                    image: __arg1_0,
+                    coordinate: __arg1_1,
+                    array_index: __arg1_2,
+                    sample: __arg1_3,
+                    level: __arg1_4,
+                },
+            ) => {
+                *__lhs_0 == *__arg1_0
+                    && *__lhs_1 == *__arg1_1
+                    && *__lhs_2 == *__arg1_2
+                    && *__lhs_3 == *__arg1_3
+                    && *__lhs_4 == *__arg1_4
+            }
+            (
+                Expression::ImageQuery {
+                    image: __lhs_0,
+                    query: __lhs_1,
+                },
+                Expression::ImageQuery {
+                    image: __arg1_0,
+                    query: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            (
+                Expression::Unary {
+                    op: __lhs_0,
+                    expr: __lhs_1,
+                },
+                Expression::Unary {
+                    op: __arg1_0,
+                    expr: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            (
+                Expression::Binary {
+                    op: __lhs_0,
+                    left: __lhs_1,
+                    right: __lhs_2,
+                },
+                Expression::Binary {
+                    op: __arg1_0,
+                    left: __arg1_1,
+                    right: __arg1_2,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1 && *__lhs_2 == *__arg1_2,
+            (
+                Expression::Select {
+                    condition: __lhs_0,
+                    accept: __lhs_1,
+                    reject: __lhs_2,
+                },
+                Expression::Select {
+                    condition: __arg1_0,
+                    accept: __arg1_1,
+                    reject: __arg1_2,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1 && *__lhs_2 == *__arg1_2,
+            (
+                Expression::Derivative {
+                    axis: __lhs_0,
+                    ctrl: __lhs_1,
+                    expr: __lhs_2,
+                },
+                Expression::Derivative {
+                    axis: __arg1_0,
+                    ctrl: __arg1_1,
+                    expr: __arg1_2,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1 && *__lhs_2 == *__arg1_2,
+            (
+                Expression::Relational {
+                    fun: __lhs_0,
+                    argument: __lhs_1,
+                },
+                Expression::Relational {
+                    fun: __arg1_0,
+                    argument: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            (
+                Expression::Math {
+                    fun: __lhs_0,
+                    arg: __lhs_1,
+                    arg1: __lhs_2,
+                    arg2: __lhs_3,
+                    arg3: __lhs_4,
+                },
+                Expression::Math {
+                    fun: __arg1_0,
+                    arg: __arg1_1,
+                    arg1: __arg1_2,
+                    arg2: __arg1_3,
+                    arg3: __arg1_4,
+                },
+            ) => {
+                *__lhs_0 == *__arg1_0
+                    && *__lhs_1 == *__arg1_1
+                    && *__lhs_2 == *__arg1_2
+                    && *__lhs_3 == *__arg1_3
+                    && *__lhs_4 == *__arg1_4
+            }
+            (
+                Expression::As {
+                    expr: __lhs_0,
+                    kind: __lhs_1,
+                    convert: __lhs_2,
+                },
+                Expression::As {
+                    expr: __arg1_0,
+                    kind: __arg1_1,
+                    convert: __arg1_2,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1 && *__lhs_2 == *__arg1_2,
+            (Expression::CallResult(__lhs_0), Expression::CallResult(__arg1_0)) => {
+                *__lhs_0 == *__arg1_0
+            }
+            (
+                Expression::AtomicResult {
+                    ty: __lhs_0,
+                    comparison: __lhs_1,
+                },
+                Expression::AtomicResult {
+                    ty: __arg1_0,
+                    comparison: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            (
+                Expression::WorkGroupUniformLoadResult { ty: __lhs_0 },
+                Expression::WorkGroupUniformLoadResult { ty: __arg1_0 },
+            ) => *__lhs_0 == *__arg1_0,
+            (Expression::ArrayLength(__lhs_0), Expression::ArrayLength(__arg1_0)) => {
+                *__lhs_0 == *__arg1_0
+            }
+            (
+                Expression::RayQueryGetIntersection {
+                    query: __lhs_0,
+                    committed: __lhs_1,
+                },
+                Expression::RayQueryGetIntersection {
+                    query: __arg1_0,
+                    committed: __arg1_1,
+                },
+            ) => *__lhs_0 == *__arg1_0 && *__lhs_1 == *__arg1_1,
+            _ => unreachable!(),
+        }
+}

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 use naga::{
-    Arena, ArraySize, Block, Constant, EntryPoint, Expression, Function, FunctionArgument,
+    Arena, Block, Constant, EntryPoint, Expression, Function, FunctionArgument,
     FunctionResult, GlobalVariable, Handle, ImageQuery, LocalVariable, Module, SampleLevel, Span,
     Statement, StructMember, SwitchCase, Type, TypeInner, UniqueArena,
 };
@@ -113,13 +113,9 @@ impl<'a> DerivedModule<'a> {
                         stride: *stride,
                     },
                     TypeInner::BindingArray { base, size } => {
-                        let size = match size {
-                            c @ ArraySize::Constant(_) => *c,
-                            ArraySize::Dynamic => ArraySize::Dynamic,
-                        };
                         TypeInner::BindingArray {
                             base: self.import_type(base),
-                            size,
+                            size: *size,
                         }
                     }
                 },

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -387,7 +387,7 @@ impl<'a> DerivedModule<'a> {
         already_imported: Rc<RefCell<HashMap<Handle<Expression>, Handle<Expression>>>>,
         new_expressions: Rc<RefCell<Arena<Expression>>>,
         non_emitting_only: bool, // only brings items that should NOT be emitted into scope
-        unique: bool, // ensure expressions are unique with custom comparison
+        unique: bool,            // ensure expressions are unique with custom comparison
     ) -> Handle<Expression> {
         if let Some(h_new) = already_imported.borrow().get(&h_expr) {
             return *h_new;
@@ -592,12 +592,11 @@ impl<'a> DerivedModule<'a> {
                     expr,
                     self.map_span(span),
                     expression_eq,
-                )    
-            } else {
-                new_expressions.borrow_mut().append(
-                    expr,
-                    self.map_span(span),
                 )
+            } else {
+                new_expressions
+                    .borrow_mut()
+                    .append(expr, self.map_span(span))
             };
 
             already_imported.borrow_mut().insert(h_expr, h_new);

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -104,17 +104,11 @@ impl<'a> DerivedModule<'a> {
                             span: *span,
                         }
                     }
-                    TypeInner::Array { base, size, stride } => {
-                        let size = match size {
-                            c @ ArraySize::Constant(_) => *c,
-                            ArraySize::Dynamic => ArraySize::Dynamic,
-                        };
-                        TypeInner::Array {
-                            base: self.import_type(base),
-                            size,
-                            stride: *stride,
-                        }
-                    }
+                    TypeInner::Array { base, size, stride } => TypeInner::Array {
+                        base: self.import_type(base),
+                        size: *size,
+                        stride: *stride,
+                    },
                     TypeInner::BindingArray { base, size } => {
                         let size = match size {
                             c @ ArraySize::Constant(_) => *c,
@@ -149,7 +143,7 @@ impl<'a> DerivedModule<'a> {
                 name: c.name.clone(),
                 r#override: c.r#override.clone(),
                 ty: self.import_type(&c.ty),
-                //TODO: infinite recursion?
+                // TODO: infinite recursion?
                 init: if c.r#override == Override::None {
                     self.import_const_expression(&c.init)
                 } else {

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,8 +1,8 @@
 use indexmap::IndexMap;
 use naga::{
-    Arena, Block, Constant, EntryPoint, Expression, Function, FunctionArgument,
-    FunctionResult, GlobalVariable, Handle, ImageQuery, LocalVariable, Module, SampleLevel, Span,
-    Statement, StructMember, SwitchCase, Type, TypeInner, UniqueArena,
+    Arena, Block, Constant, EntryPoint, Expression, Function, FunctionArgument, FunctionResult,
+    GlobalVariable, Handle, ImageQuery, LocalVariable, Module, SampleLevel, Span, Statement,
+    StructMember, SwitchCase, Type, TypeInner, UniqueArena,
 };
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
@@ -112,12 +112,10 @@ impl<'a> DerivedModule<'a> {
                         size: *size,
                         stride: *stride,
                     },
-                    TypeInner::BindingArray { base, size } => {
-                        TypeInner::BindingArray {
-                            base: self.import_type(base),
-                            size: *size,
-                        }
-                    }
+                    TypeInner::BindingArray { base, size } => TypeInner::BindingArray {
+                        base: self.import_type(base),
+                        size: *size,
+                    },
                 },
             };
             let span = self.shader.as_ref().unwrap().types.get_span(*h_type);

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use naga::{
-    Arena, ArraySize, Block, Constant, ConstantInner, EntryPoint, Expression, Function,
-    FunctionArgument, FunctionResult, GlobalVariable, Handle, ImageQuery, LocalVariable, Module,
+    Arena, ArraySize, Block, Constant, EntryPoint, Expression, Function, FunctionArgument,
+    FunctionResult, GlobalVariable, Handle, ImageQuery, LocalVariable, Module, Override,
     SampleLevel, Span, Statement, StructMember, SwitchCase, Type, TypeInner, UniqueArena,
 };
 use std::collections::HashMap;
@@ -13,11 +13,13 @@ pub struct DerivedModule<'a> {
 
     type_map: HashMap<Handle<Type>, Handle<Type>>,
     const_map: HashMap<Handle<Constant>, Handle<Constant>>,
+    const_expression_map: HashMap<Handle<Expression>, Handle<Expression>>,
     global_map: HashMap<Handle<GlobalVariable>, Handle<GlobalVariable>>,
     function_map: HashMap<String, Handle<Function>>,
 
     types: UniqueArena<Type>,
     constants: Arena<Constant>,
+    const_expressions: Arena<Expression>,
     globals: Arena<GlobalVariable>,
     functions: Arena<Function>,
 }
@@ -104,7 +106,7 @@ impl<'a> DerivedModule<'a> {
                     }
                     TypeInner::Array { base, size, stride } => {
                         let size = match size {
-                            ArraySize::Constant(c) => ArraySize::Constant(self.import_const(c)),
+                            c @ ArraySize::Constant(_) => *c,
                             ArraySize::Dynamic => ArraySize::Dynamic,
                         };
                         TypeInner::Array {
@@ -115,7 +117,7 @@ impl<'a> DerivedModule<'a> {
                     }
                     TypeInner::BindingArray { base, size } => {
                         let size = match size {
-                            ArraySize::Constant(c) => ArraySize::Constant(self.import_const(c)),
+                            c @ ArraySize::Constant(_) => *c,
                             ArraySize::Dynamic => ArraySize::Dynamic,
                         };
                         TypeInner::BindingArray {
@@ -145,16 +147,14 @@ impl<'a> DerivedModule<'a> {
 
             let new_const = Constant {
                 name: c.name.clone(),
-                specialization: c.specialization,
-                inner: match &c.inner {
-                    ConstantInner::Scalar { .. } => c.inner.clone(),
-                    ConstantInner::Composite { ty, components } => {
-                        let components = components.iter().map(|c| self.import_const(c)).collect();
-                        ConstantInner::Composite {
-                            ty: self.import_type(ty),
-                            components,
-                        }
-                    }
+                r#override: c.r#override.clone(),
+                ty: self.import_type(&c.ty),
+                //TODO: infinite recursion?
+                init: if c.r#override == Override::None {
+                    self.import_const_expression(&c.init)
+                } else {
+                    // r#override doesn't do anything now
+                    unreachable!()
                 },
             };
 
@@ -183,7 +183,7 @@ impl<'a> DerivedModule<'a> {
                 space: gv.space,
                 binding: gv.binding.clone(),
                 ty: self.import_type(&gv.ty),
-                init: gv.init.map(|c| self.import_const(&c)),
+                init: gv.init.map(|c| self.import_const_expression(&c)),
             };
 
             let span = self
@@ -198,6 +198,63 @@ impl<'a> DerivedModule<'a> {
             self.global_map.insert(*h_global, new_h);
             new_h
         })
+    }
+    // remap a const expression from source context into our derived context
+    pub fn import_const_expression(
+        &mut self,
+        const_expression_handle: &Handle<Expression>,
+    ) -> Handle<Expression> {
+        self.const_expression_map
+            .get(const_expression_handle)
+            .copied()
+            .unwrap_or_else(|| {
+                let old_c = self
+                    .shader
+                    .as_ref()
+                    .unwrap()
+                    .const_expressions
+                    .try_get(*const_expression_handle)
+                    .unwrap();
+
+                let new_const = match old_c {
+                    Expression::Constant(h_c) => {
+                        let c = self
+                            .shader
+                            .as_ref()
+                            .unwrap()
+                            .constants
+                            .try_get(*h_c)
+                            .unwrap();
+
+                        Constant {
+                            name: c.name.clone(),
+                            r#override: c.r#override.clone(),
+                            ty: self.import_type(&c.ty),
+                            init: self.import_const_expression(&c.init),
+                        }
+                    }
+                    // TODO
+                    // What should I do?
+                    _ => todo!(),
+                };
+
+                let span = self
+                    .shader
+                    .as_ref()
+                    .unwrap()
+                    .const_expressions
+                    .get_span(*const_expression_handle);
+                let new_constant_handle = self
+                    .constants
+                    .fetch_or_append(new_const, self.map_span(span));
+                let new_const_expression = naga::Expression::Constant(new_constant_handle);
+                let new_const_expression_handle = self
+                    .const_expressions
+                    .append(new_const_expression, self.map_span(span));
+                self.const_expression_map
+                    .insert(*const_expression_handle, new_const_expression_handle);
+                new_const_expression_handle
+            })
     }
 
     // remap a block
@@ -325,6 +382,12 @@ impl<'a> DerivedModule<'a> {
                         value: map_expr!(value),
                         result: map_expr!(result),
                     },
+                    Statement::WorkGroupUniformLoad { pointer, result } => {
+                        Statement::WorkGroupUniformLoad {
+                            pointer: map_expr!(pointer),
+                            result: map_expr!(result),
+                        }
+                    }
                     Statement::Return { value } => Statement::Return {
                         value: map_expr_opt!(value),
                     },
@@ -406,6 +469,8 @@ impl<'a> DerivedModule<'a> {
         let mut is_external = false;
         let expr = old_expressions.try_get(h_expr).unwrap();
         let expr = match expr {
+            Expression::Literal(_) => expr.clone(),
+            Expression::ZeroValue(zv) => Expression::ZeroValue(self.import_type(zv)),
             Expression::CallResult(f) => Expression::CallResult(self.map_function_handle(f)),
             Expression::Constant(c) => {
                 is_external = true;
@@ -434,7 +499,7 @@ impl<'a> DerivedModule<'a> {
                 gather: *gather,
                 coordinate: map_expr!(coordinate),
                 array_index: map_expr_opt!(array_index),
-                offset: offset.map(|c| self.import_const(&c)),
+                offset: offset.map(|c| self.import_const_expression(&c)),
                 level: match level {
                     SampleLevel::Auto | SampleLevel::Zero => *level,
                     SampleLevel::Exact(expr) => SampleLevel::Exact(map_expr!(expr)),
@@ -549,6 +614,7 @@ impl<'a> DerivedModule<'a> {
             }
 
             Expression::AtomicResult { .. } => expr.clone(),
+            Expression::WorkGroupUniformLoadResult { .. } => expr.clone(),
             Expression::RayQueryProceedResult => expr.clone(),
             Expression::RayQueryGetIntersection { query, committed } => {
                 Expression::RayQueryGetIntersection {
@@ -591,7 +657,7 @@ impl<'a> DerivedModule<'a> {
             let new_local = LocalVariable {
                 name: l.name.clone(),
                 ty: self.import_type(&l.ty),
-                init: l.init.map(|c| self.import_const(&c)),
+                init: l.init.map(|c| self.import_const_expression(&c)),
             };
             let span = func.local_variables.get_span(h_l);
             let new_h = local_variables.append(new_local, self.map_span(span));
@@ -688,6 +754,7 @@ impl<'a> From<DerivedModule<'a>> for naga::Module {
             types: derived.types,
             constants: derived.constants,
             global_variables: derived.globals,
+            const_expressions: derived.const_expressions,
             functions: derived.functions,
             special_types: Default::default(),
             entry_points: Default::default(),

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -62,6 +62,7 @@ impl Redirector {
                 | Statement::Break
                 | Statement::Continue
                 | Statement::Return { .. }
+                | Statement::WorkGroupUniformLoad { .. }
                 | Statement::Kill
                 | Statement::Barrier(_)
                 | Statement::Store { .. }


### PR DESCRIPTION
fixes #33

this should not merged until bevy 0.11.1 is out. builds on @VitalyAnkh's partial migration, with additionally :

- use `Rc<RefCell>` for `const_expressions` and `const_expr_map` - this is basically unavoidable, as `DerivedModule::import_expression` needs access to both the `const_expressions` and the arena to import into, which may also be `const_expressions`
- don't emit `Expression::Literal` and `Expression::ZeroValue`s
- enforce `const_expression` uniqueness with a custom impl of `PartialEq` for `Expression`s, to ensure that the uniqueness test for globals and consts still passes (else we end up with duplicated items, they no longer test as equal as they refer to different `init` expressions). this could be removed if the `PartialEq` derive on `Expression` in naga is made externally available.
- a basic port of the `prune` module which just leaves all `const_expressions` present

the tests pass, but i haven't tried integrating into bevy (which will require bevy to use wgpu 0.17).