### PR TITLE
don't colorize errors in wasm

### DIFF
--- a/src/compose/error.rs
+++ b/src/compose/error.rs
@@ -185,9 +185,9 @@ impl ComposerError {
 
         let files = SimpleFile::new(path, source.as_str());
         let config = term::Config::default();
-        #[cfg(test)]
+        #[cfg(any(test, target_arch = "wasm32"))]
         let mut writer = term::termcolor::NoColor::new(Vec::new());
-        #[cfg(not(test))]
+        #[cfg(not(any(test, target_arch = "wasm32")))]
         let mut writer = term::termcolor::Ansi::new(Vec::new());
 
         let (labels, notes) = match &self.inner {


### PR DESCRIPTION
in wasm, errors are printed to the console.
This can gives something like:
```
ERROR crates/bevy_render/src/render_resource/pipeline_cache.rs:812 failed to process shader:
�[0m�[1m�[38;5;9merror�[0m�[1m: expected ']', found '32'�[0m
   �[0m�[34m┌─�[0m crates/bevy_pbr/src/render/mesh.wgsl:69:82
   �[0m�[34m│�[0m
�[0m�[34m69�[0m �[0m�[34m│�[0m     var model = bevy_pbr::mesh_bindings::mesh[0u�[0m�[31m32�[0m].model;
   �[0m�[34m│�[0m                                                                                  �[0m�[31m^^�[0m �[0m�[31mexpected ']'�[0m
   �[0m�[34m│�[0m
   �[0m�[34m=�[0m expected ']', found '32'
```

This PR disable term colors in wasm