### PR TITLE
Update `regex` and `regex-syntax` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ override_any = []
 [dependencies]
 naga = { version = "0.13", features = ["wgsl-in", "wgsl-out", "glsl-in", "glsl-out", "clone", "span"] }
 tracing = "0.1"
-regex = "1.5"
-regex-syntax = "0.6"
+regex = "1.8"
+regex-syntax = "0.7"
 thiserror = "1.0"
 codespan-reporting = "0.11"
 data-encoding = "2.3.2"
@@ -29,6 +29,6 @@ once_cell = "1.17.0"
 indexmap = "1.9.3"
 
 [dev-dependencies]
-wgpu = { version = "0.17", features=["naga"] }
+wgpu = { version = "0.17", features = ["naga"] }
 futures-lite = "1"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt"] }


### PR DESCRIPTION
Reduces dependency duplication throughout bevy's dependency tree (other crates use 0.7 while this one uses 0.6)