### PR TITLE
Add 'glsl' feature to gate naga glsl features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
       - name: Check
-        run: cargo check
+        run: |
+          cargo check
+          cargo check --no-default-features
 
   check-wasm:
     name: Check (Wasm)
@@ -21,7 +23,9 @@ jobs:
         with:
           target: wasm32-unknown-unknown
       - name: Check wasm
-        run: cargo check --target wasm32-unknown-unknown
+        run: |
+          cargo check --target wasm32-unknown-unknown
+          cargo check --target wasm32-unknown-unknown --no-default-features
 
   test-windows:
     name: Test Suite (Windows)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,15 @@ repository = "https://github.com/bevyengine/naga_oil/"
 readme = "README.md"
 
 [features]
-default = ["test_shader"]
+default = ["test_shader", "glsl"]
 # enable tests that need a graphical card
 test_shader = []
 prune = []
 override_any = []
+glsl = ["naga/glsl-in", "naga/glsl-out"]
 
 [dependencies]
-naga = { version = "0.13", features = ["wgsl-in", "wgsl-out", "glsl-in", "glsl-out", "clone", "span"] }
+naga = { version = "0.13", features = ["wgsl-in", "wgsl-out", "clone", "span"] }
 tracing = "0.1"
 regex = "1.8"
 regex-syntax = "0.7"

--- a/src/compose/error.rs
+++ b/src/compose/error.rs
@@ -81,10 +81,12 @@ pub enum ComposerErrorInner {
     ImportNotFound(String, usize),
     #[error("{0}")]
     WgslParseError(naga::front::wgsl::ParseError),
+    #[cfg(feature = "glsl")]
     #[error("{0:?}")]
     GlslParseError(Vec<naga::front::glsl::Error>),
     #[error("naga_oil bug, please file a report: failed to convert imported module IR back into WGSL for use with WGSL shaders: {0}")]
     WgslBackError(naga::back::wgsl::Error),
+    #[cfg(feature = "glsl")]
     #[error("naga_oil bug, please file a report: failed to convert imported module IR back into GLSL for use with GLSL shaders: {0}")]
     GlslBackError(naga::back::glsl::Error),
     #[error("naga_oil bug, please file a report: composer failed to build a valid header: {0}")]
@@ -223,6 +225,7 @@ impl ComposerError {
                     .collect(),
                 vec![e.message().to_owned()],
             ),
+            #[cfg(feature = "glsl")]
             ComposerErrorInner::GlslParseError(e) => (
                 e.iter()
                     .map(|naga::front::glsl::Error { kind, meta }| {
@@ -247,6 +250,7 @@ impl ComposerError {
             ComposerErrorInner::WgslBackError(e) => {
                 return format!("{path}: wgsl back error: {e}");
             }
+            #[cfg(feature = "glsl")]
             ComposerErrorInner::GlslBackError(e) => {
                 return format!("{path}: glsl back error: {e}");
             }

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -1146,6 +1146,7 @@ impl Composer {
 
         if self.validate && create_headers {
             // check that identifiers haven't been renamed
+            #[allow(clippy::single_element_loop)]
             for language in [
                 ShaderLanguage::Wgsl,
                 #[cfg(feature = "glsl")]

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -300,6 +300,7 @@ mod test {
         output_eq!(text, "tests/expected/missing_import.txt");
     }
 
+    #[cfg(feature = "glsl")]
     #[test]
     fn wgsl_call_glsl() {
         let mut composer = Composer::default();
@@ -351,6 +352,7 @@ mod test {
         let _ = wgsl;
     }
 
+    #[cfg(feature = "glsl")]
     #[test]
     fn glsl_call_wgsl() {
         let mut composer = Composer::default();
@@ -391,6 +393,7 @@ mod test {
         output_eq!(wgsl, "tests/expected/glsl_call_wgsl.txt");
     }
 
+    #[cfg(feature = "glsl")]
     #[test]
     fn basic_glsl() {
         let mut composer = Composer::default();
@@ -679,6 +682,7 @@ mod test {
         output_eq!(wgsl, "tests/expected/import_in_decl.txt");
     }
 
+    #[cfg(feature = "glsl")]
     #[test]
     fn glsl_const_import() {
         let mut composer = Composer::default();
@@ -720,6 +724,7 @@ mod test {
         output_eq!(wgsl, "tests/expected/glsl_const_import.txt");
     }
 
+    #[cfg(feature = "glsl")]
     #[test]
     fn glsl_wgsl_const_import() {
         let mut composer = Composer::default();
@@ -759,6 +764,7 @@ mod test {
 
         output_eq!(wgsl, "tests/expected/glsl_wgsl_const_import.txt");
     }
+    #[cfg(feature = "glsl")]
     #[test]
     fn wgsl_glsl_const_import() {
         let mut composer = Composer::default();


### PR DESCRIPTION
This can be used to reduce the final binary size when a consumer only needs WGSL support. I've enabled the feature by default for backwards-compatibility