### PR TITLE
add newline in import loop to fix error locations

### DIFF
--- a/src/compose/preprocess.rs
+++ b/src/compose/preprocess.rs
@@ -288,7 +288,7 @@ impl Preprocessor {
                             break;
                         }
 
-                        final_string.push_str("\n");
+                        final_string.push('\n');
                         line = lines.next().unwrap().0;
                     }
 

--- a/src/compose/preprocess.rs
+++ b/src/compose/preprocess.rs
@@ -288,6 +288,7 @@ impl Preprocessor {
                             break;
                         }
 
+                        final_string.push_str("\n");
                         line = lines.next().unwrap().0;
                     }
 


### PR DESCRIPTION
error span offsets are incorrectly reported with preceding multi-line imports. 

add a "\n" for each multiline import to get the correct source location.