### PR TITLE
non-scope defs are effective

### DIFF
--- a/src/compose/preprocess.rs
+++ b/src/compose/preprocess.rs
@@ -468,6 +468,14 @@ impl Preprocessor {
                     return Err(ComposerErrorInner::DefineInModule(offset));
                 }
             } else {
+                for cap in self
+                    .def_regex
+                    .captures_iter(&line)
+                    .chain(self.def_regex_delimited.captures_iter(&line))
+                {
+                    effective_defs.insert(cap.get(1).unwrap().as_str().to_owned());
+                }
+
                 substitute_identifiers(&line, offset, &declared_imports, &mut used_imports, true)
                     .unwrap();
             }


### PR DESCRIPTION
fixes bevyengine/bevy#10533

shader defs used only in literal substitutions (`#MY_DEF` or `#{MY_DEF}`) were not counted towards the module's effective defs, so were not validated when looking for an existing cached version of the module.

add them to effective defs.