### PR TITLE
Deterministic output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga_oil"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "a crate for combining and manipulating shaders using naga IR"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga_oil"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "a crate for combining and manipulating shaders using naga IR"

--- a/src/compose/parse_imports.rs
+++ b/src/compose/parse_imports.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use super::{
     tokenizer::{Token, Tokenizer},
@@ -7,7 +7,7 @@ use super::{
 
 pub fn parse_imports<'a>(
     input: &'a str,
-    declared_imports: &mut HashMap<String, Vec<String>>,
+    declared_imports: &mut IndexMap<String, Vec<String>>,
 ) -> Result<(), (&'a str, usize)> {
     let mut tokens = Tokenizer::new(input, false).peekable();
 
@@ -116,8 +116,8 @@ pub fn parse_imports<'a>(
 pub fn substitute_identifiers(
     input: &str,
     offset: usize,
-    declared_imports: &HashMap<String, Vec<String>>,
-    used_imports: &mut HashMap<String, ImportDefWithOffset>,
+    declared_imports: &IndexMap<String, Vec<String>>,
+    used_imports: &mut IndexMap<String, ImportDefWithOffset>,
     allow_ambiguous: bool,
 ) -> Result<String, usize> {
     let tokens = Tokenizer::new(input, true);
@@ -193,8 +193,8 @@ pub fn substitute_identifiers(
 }
 
 #[cfg(test)]
-fn test_parse(input: &str) -> Result<HashMap<String, Vec<String>>, (&str, usize)> {
-    let mut declared_imports = HashMap::default();
+fn test_parse(input: &str) -> Result<IndexMap<String, Vec<String>>, (&str, usize)> {
+    let mut declared_imports = IndexMap::default();
     parse_imports(input, &mut declared_imports)?;
     Ok(declared_imports)
 }
@@ -206,7 +206,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([(
+        Ok(IndexMap::from_iter([(
             "b".to_owned(),
             vec!("a::b".to_owned())
         )]))
@@ -217,7 +217,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             ("b".to_owned(), vec!("a::b".to_owned())),
             ("c".to_owned(), vec!("a::c".to_owned())),
         ]))
@@ -228,7 +228,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             ("d".to_owned(), vec!("a::b".to_owned())),
             ("c".to_owned(), vec!("a::c".to_owned())),
         ]))
@@ -239,7 +239,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             ("c".to_owned(), vec!("a::b::c".to_owned())),
             ("d".to_owned(), vec!("a::b::d".to_owned())),
             ("e".to_owned(), vec!("a::e".to_owned())),
@@ -251,7 +251,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             ("c".to_owned(), vec!("a::b::c".to_owned())),
             ("d".to_owned(), vec!("a::b::d".to_owned())),
             ("e".to_owned(), vec!("e".to_owned())),
@@ -263,7 +263,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             ("a".to_owned(), vec!("a".to_owned())),
             ("b".to_owned(), vec!("b".to_owned())),
         ]))
@@ -274,7 +274,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             ("c".to_owned(), vec!("a::b::c".to_owned())),
             ("d".to_owned(), vec!("a::b::d".to_owned())),
         ]))
@@ -285,7 +285,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([(
+        Ok(IndexMap::from_iter([(
             "c".to_owned(),
             vec!("a::b::c".to_owned())
         ),]))
@@ -296,7 +296,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             ("d".to_owned(), vec!("a::b::c::d".to_owned())),
             ("e".to_owned(), vec!("a::b::c::e".to_owned())),
             ("f".to_owned(), vec!("a::b::f".to_owned())),
@@ -317,7 +317,7 @@ fn import_tokens() {
     ";
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             ("d".to_owned(), vec!("a::b::c::d".to_owned())),
             ("e".to_owned(), vec!("a::b::c::e".to_owned())),
             ("f".to_owned(), vec!("a::b::f".to_owned())),
@@ -331,7 +331,7 @@ fn import_tokens() {
     "#;
     assert_eq!(
         test_parse(input),
-        Ok(HashMap::from_iter([
+        Ok(IndexMap::from_iter([
             (
                 "a".to_owned(),
                 vec!(r#""path//with\ all sorts of .stuff"::a"#.to_owned())

--- a/src/compose/preprocess.rs
+++ b/src/compose/preprocess.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use indexmap::IndexMap;
 use regex::Regex;
 
 use super::{
@@ -234,8 +235,8 @@ impl Preprocessor {
         shader_defs: &HashMap<String, ShaderDefValue>,
         validate_len: bool,
     ) -> Result<PreprocessOutput, ComposerErrorInner> {
-        let mut declared_imports = HashMap::new();
-        let mut used_imports = HashMap::new();
+        let mut declared_imports = IndexMap::new();
+        let mut used_imports = IndexMap::new();
         let mut scope = Scope::new();
         let mut final_string = String::new();
         let mut offset = 0;
@@ -390,8 +391,8 @@ impl Preprocessor {
         shader_str: &str,
         allow_defines: bool,
     ) -> Result<PreprocessorMetaData, ComposerErrorInner> {
-        let mut declared_imports = HashMap::default();
-        let mut used_imports = HashMap::default();
+        let mut declared_imports = IndexMap::default();
+        let mut used_imports = IndexMap::default();
         let mut name = None;
         let mut offset = 0;
         let mut defines = HashMap::default();

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -339,7 +339,7 @@ mod test {
         // f.write_all(wgsl.as_bytes()).unwrap();
         // drop(f);
 
-        assert_eq!(wgsl, include_str!("tests/expected/wgsl_call_glsl.txt"));
+        output_eq!(wgsl, "tests/expected/wgsl_call_glsl.txt");
     }
 
     #[cfg(feature = "glsl")]

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -156,9 +156,6 @@ mod test {
             naga::back::wgsl::WriterFlags::EXPLICIT_TYPES,
         )
         .unwrap();
-        let mut wgsl: Vec<_> = wgsl.lines().collect();
-        wgsl.sort();
-        let wgsl = wgsl.join("\n");
 
         // println!("{}", wgsl);
         // let mut f = std::fs::File::create("dup_import.txt").unwrap();
@@ -338,21 +335,11 @@ mod test {
         )
         .unwrap();
 
-        // unfortunately glsl variables are emitted in random order...
-        // so this is better than nothing
-        let mut wgsl: Vec<_> = wgsl.lines().collect();
-        wgsl.sort();
-        let wgsl = wgsl.join("\n");
-
         // let mut f = std::fs::File::create("wgsl_call_glsl.txt").unwrap();
         // f.write_all(wgsl.as_bytes()).unwrap();
         // drop(f);
 
-        // assert_eq!(wgsl, include_str!("tests/expected/wgsl_call_glsl.txt"));
-
-        // actually it's worse than that ... glsl output seems volatile over struct names
-        // i suppose at least we are testing that it doesn't throw any errors ..?
-        let _ = wgsl;
+        assert_eq!(wgsl, include_str!("tests/expected/wgsl_call_glsl.txt"));
     }
 
     #[cfg(feature = "glsl")]
@@ -852,11 +839,6 @@ mod test {
         )
         .unwrap();
 
-        // println!("{}", wgsl);
-        let mut wgsl = wgsl.lines().collect::<Vec<_>>();
-        wgsl.sort();
-        let wgsl = wgsl.join("\n");
-
         // let mut f = std::fs::File::create("item_import_test.txt").unwrap();
         // f.write_all(wgsl.as_bytes()).unwrap();
         // drop(f);
@@ -923,9 +905,6 @@ mod test {
             naga::back::wgsl::WriterFlags::EXPLICIT_TYPES,
         )
         .unwrap();
-        let mut wgsl: Vec<_> = wgsl.lines().collect();
-        wgsl.sort();
-        let wgsl = wgsl.join("\n");
 
         // let mut f = std::fs::File::create("bad_identifiers.txt").unwrap();
         // f.write_all(wgsl.as_bytes()).unwrap();
@@ -992,9 +971,6 @@ mod test {
             naga::back::wgsl::WriterFlags::EXPLICIT_TYPES,
         )
         .unwrap();
-        let mut wgsl: Vec<_> = wgsl.lines().collect();
-        wgsl.sort();
-        let wgsl = wgsl.join("\n");
 
         // let mut f = std::fs::File::create("dup_struct_import.txt").unwrap();
         // f.write_all(wgsl.as_bytes()).unwrap();

--- a/src/compose/tests/expected/bad_identifiers.txt
+++ b/src/compose/tests/expected/bad_identifiers.txt
@@ -1,39 +1,39 @@
-
-
-
-
-
-
-
-
-    d.fine = 3f;
-    e.fine_member = 4f;
+struct IsFineX_naga_oil_mod_XON2HE5LDORZQX {
     fine: f32,
+}
+
+struct Isbad_X_naga_oil_mod_XON2HE5LDORZQX {
     fine_member: f32,
-    let _e1: f32 = fineX_naga_oil_mod_XMZXHGX(1f);
-    let _e20: f32 = d.fine;
-    let _e23: f32 = e.fine_member;
-    let _e3: f32 = bad_X_naga_oil_mod_XMZXHGX(2f);
-    let _e6: f32 = fineX_naga_oil_mod_XM5WG6YTBNRZQX;
-    let _e8: f32 = bad_X_naga_oil_mod_XM5WG6YTBNRZQX;
-    let b: f32 = (_e1 + _e3);
-    let c: f32 = (_e6 + _e8);
-    return ((((2f + b) + c) + _e20) + _e23);
+}
+
+const fineX_naga_oil_mod_XMNXW443UOMX: f32 = 1f;
+const bad_X_naga_oil_mod_XMNXW443UOMX: f32 = 1f;
+
+var<private> fineX_naga_oil_mod_XM5WG6YTBNRZQX: f32 = 1f;
+var<private> bad_X_naga_oil_mod_XM5WG6YTBNRZQX: f32 = 1f;
+
+fn fineX_naga_oil_mod_XMZXHGX(in: f32) -> f32 {
     return in;
+}
+
+fn bad_X_naga_oil_mod_XMZXHGX(in_1: f32) -> f32 {
     return in_1;
+}
+
+fn main() -> f32 {
     var d: IsFineX_naga_oil_mod_XON2HE5LDORZQX;
     var e: Isbad_X_naga_oil_mod_XON2HE5LDORZQX;
-const bad_X_naga_oil_mod_XMNXW443UOMX: f32 = 1f;
-const fineX_naga_oil_mod_XMNXW443UOMX: f32 = 1f;
-fn bad_X_naga_oil_mod_XMZXHGX(in_1: f32) -> f32 {
-fn fineX_naga_oil_mod_XMZXHGX(in: f32) -> f32 {
-fn main() -> f32 {
-struct IsFineX_naga_oil_mod_XON2HE5LDORZQX {
-struct Isbad_X_naga_oil_mod_XON2HE5LDORZQX {
-var<private> bad_X_naga_oil_mod_XM5WG6YTBNRZQX: f32 = 1f;
-var<private> fineX_naga_oil_mod_XM5WG6YTBNRZQX: f32 = 1f;
+
+    let _e1: f32 = fineX_naga_oil_mod_XMZXHGX(1f);
+    let _e3: f32 = bad_X_naga_oil_mod_XMZXHGX(2f);
+    let b: f32 = (_e1 + _e3);
+    let _e6: f32 = fineX_naga_oil_mod_XM5WG6YTBNRZQX;
+    let _e8: f32 = bad_X_naga_oil_mod_XM5WG6YTBNRZQX;
+    let c: f32 = (_e6 + _e8);
+    d.fine = 3f;
+    e.fine_member = 4f;
+    let _e20: f32 = d.fine;
+    let _e23: f32 = e.fine_member;
+    return ((((2f + b) + c) + _e20) + _e23);
 }
-}
-}
-}
-}
+

--- a/src/compose/tests/expected/dup_import.txt
+++ b/src/compose/tests/expected/dup_import.txt
@@ -1,16 +1,16 @@
+const PIX_naga_oil_mod_XMNXW443UOMX: f32 = 3.1f;
 
+fn fX_naga_oil_mod_XMEX() -> f32 {
+    return 3.1f;
+}
 
+fn fX_naga_oil_mod_XMIX() -> f32 {
+    return 6.2f;
+}
 
-
+fn main() -> f32 {
     let _e0: f32 = fX_naga_oil_mod_XMEX();
     let _e1: f32 = fX_naga_oil_mod_XMIX();
     return (_e0 * _e1);
-    return 3.1f;
-    return 6.2f;
-const PIX_naga_oil_mod_XMNXW443UOMX: f32 = 3.1f;
-fn fX_naga_oil_mod_XMEX() -> f32 {
-fn fX_naga_oil_mod_XMIX() -> f32 {
-fn main() -> f32 {
 }
-}
-}
+

--- a/src/compose/tests/expected/dup_struct_import.txt
+++ b/src/compose/tests/expected/dup_struct_import.txt
@@ -1,26 +1,26 @@
+struct MyStructX_naga_oil_mod_XON2HE5LDOQX {
+    value: f32,
+}
 
+fn aX_naga_oil_mod_XMEX() -> MyStructX_naga_oil_mod_XON2HE5LDOQX {
+    var s_a: MyStructX_naga_oil_mod_XON2HE5LDOQX;
 
+    s_a.value = 1f;
+    let _e3: MyStructX_naga_oil_mod_XON2HE5LDOQX = s_a;
+    return _e3;
+}
 
+fn bX_naga_oil_mod_XMIX() -> MyStructX_naga_oil_mod_XON2HE5LDOQX {
+    var s_b: MyStructX_naga_oil_mod_XON2HE5LDOQX;
 
+    s_b.value = 2f;
+    let _e3: MyStructX_naga_oil_mod_XON2HE5LDOQX = s_b;
+    return _e3;
+}
 
-
+fn main() -> f32 {
     let _e0: MyStructX_naga_oil_mod_XON2HE5LDOQX = aX_naga_oil_mod_XMEX();
     let _e1: MyStructX_naga_oil_mod_XON2HE5LDOQX = bX_naga_oil_mod_XMIX();
-    let _e3: MyStructX_naga_oil_mod_XON2HE5LDOQX = s_a;
-    let _e3: MyStructX_naga_oil_mod_XON2HE5LDOQX = s_b;
     return (_e0.value / _e1.value);
-    return _e3;
-    return _e3;
-    s_a.value = 1f;
-    s_b.value = 2f;
-    value: f32,
-    var s_a: MyStructX_naga_oil_mod_XON2HE5LDOQX;
-    var s_b: MyStructX_naga_oil_mod_XON2HE5LDOQX;
-fn aX_naga_oil_mod_XMEX() -> MyStructX_naga_oil_mod_XON2HE5LDOQX {
-fn bX_naga_oil_mod_XMIX() -> MyStructX_naga_oil_mod_XON2HE5LDOQX {
-fn main() -> f32 {
-struct MyStructX_naga_oil_mod_XON2HE5LDOQX {
 }
-}
-}
-}
+

--- a/src/compose/tests/expected/item_import_test.txt
+++ b/src/compose/tests/expected/item_import_test.txt
@@ -1,17 +1,17 @@
-
-
-
-
-    let _e1: u32 = doubleX_naga_oil_mod_XMNXW443UOMX(XX_naga_oil_mod_XMNXW443UOMX);
-    let _e1: u32 = doubleX_naga_oil_mod_XMNXW443UOMX(YX_naga_oil_mod_XMNXW443UOMX);
-    return (in * 2u);
-    return _e1;
-    return _e1;
 const XX_naga_oil_mod_XMNXW443UOMX: u32 = 1u;
 const YX_naga_oil_mod_XMNXW443UOMX: u32 = 2u;
+
 fn doubleX_naga_oil_mod_XMNXW443UOMX(in: u32) -> u32 {
+    return (in * 2u);
+}
+
 fn main() -> u32 {
+    let _e1: u32 = doubleX_naga_oil_mod_XMNXW443UOMX(XX_naga_oil_mod_XMNXW443UOMX);
+    return _e1;
+}
+
 fn other() -> u32 {
+    let _e1: u32 = doubleX_naga_oil_mod_XMNXW443UOMX(YX_naga_oil_mod_XMNXW443UOMX);
+    return _e1;
 }
-}
-}
+

--- a/src/compose/tests/expected/wgsl_call_glsl.txt
+++ b/src/compose/tests/expected/wgsl_call_glsl.txt
@@ -1,48 +1,16 @@
-
-
-
-
-
-
-
-
-    @location(0) o_Target: vec4<f32>,
-    @location(0) o_Target: vec4<f32>,
+struct CustomMaterialX_naga_oil_mod_XM5WHG3C7NVXWI5LMMUX {
     Color: vec4<f32>,
-    _ = (&global.Color);
-    _ = (&global.Color);
-    _ = _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberv_Uv;
-    _naga_oil_mod_M5WHG3C7NVXWI5LMMU_membermain();
-    _naga_oil_mod_M5WHG3C7NVXWI5LMMU_membero_Target = (_e6 * _e9);
-    _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberv_Uv = v_Uv;
-    let _e13: vec4<f32> = _naga_oil_mod_M5WHG3C7NVXWI5LMMU_membero_Target;
-    let _e4: f32 = _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberglsl_func();
-    let _e6: vec4<f32> = global.Color;
-    let _e8: vec2<f32> = _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberv_Uv;
-    let _e9: vec4<f32> = textureSample(_naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberCustomMaterial_texture, _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberCustomMaterial_sampler, _e8);
-    return 3.0;
-    return _e4;
-    return type_5(_e13);
-    return;
+}
+
 @group(1) @binding(0) 
-@group(1) @binding(1) 
-@group(1) @binding(2) 
-fn _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberglsl_func() -> f32 {
-fn _naga_oil_mod_M5WHG3C7NVXWI5LMMU_membermain() {
-fn _naga_oil_mod_M5WHG3C7NVXWI5LMMU_membermain_1(@location(0) v_Uv: vec2<f32>) -> type_5 {
+var<uniform> global: CustomMaterialX_naga_oil_mod_XM5WHG3C7NVXWI5LMMUX;
+
+fn glsl_funcX_naga_oil_mod_XM5WHG3C7NVXWI5LMMUX() -> f32 {
+    return 3f;
+}
+
 fn fraggo() -> f32 {
-struct _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberCustomMaterial {
-struct type_5 {
-struct type_5_ {
-var _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberCustomMaterial_sampler: sampler;
-var _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberCustomMaterial_texture: texture_2d<f32>;
-var<private> _naga_oil_mod_M5WHG3C7NVXWI5LMMU_membero_Target: vec4<f32>;
-var<private> _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberv_Uv: vec2<f32>;
-var<uniform> global: _naga_oil_mod_M5WHG3C7NVXWI5LMMU_memberCustomMaterial;
+    let _e0: f32 = glsl_funcX_naga_oil_mod_XM5WHG3C7NVXWI5LMMUX();
+    return _e0;
 }
-}
-}
-}
-}
-}
-}
+

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -4,7 +4,7 @@ use naga::{
     FunctionResult, GlobalVariable, Handle, ImageQuery, LocalVariable, Module, SampleLevel, Span,
     Statement, StructMember, SwitchCase, Type, TypeInner, UniqueArena,
 };
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 use crate::compose::util::expression_eq;
 
@@ -13,11 +13,11 @@ pub struct DerivedModule<'a> {
     shader: Option<&'a Module>,
     span_offset: usize,
 
-    type_map: HashMap<Handle<Type>, Handle<Type>>,
-    const_map: HashMap<Handle<Constant>, Handle<Constant>>,
-    const_expression_map: Rc<RefCell<HashMap<Handle<Expression>, Handle<Expression>>>>,
-    global_map: HashMap<Handle<GlobalVariable>, Handle<GlobalVariable>>,
-    function_map: HashMap<String, Handle<Function>>,
+    type_map: IndexMap<Handle<Type>, Handle<Type>>,
+    const_map: IndexMap<Handle<Constant>, Handle<Constant>>,
+    const_expression_map: Rc<RefCell<IndexMap<Handle<Expression>, Handle<Expression>>>>,
+    global_map: IndexMap<Handle<GlobalVariable>, Handle<GlobalVariable>>,
+    function_map: IndexMap<String, Handle<Function>>,
 
     types: UniqueArena<Type>,
     constants: Arena<Constant>,
@@ -201,7 +201,7 @@ impl<'a> DerivedModule<'a> {
         &mut self,
         block: &Block,
         old_expressions: &Arena<Expression>,
-        already_imported: Rc<RefCell<HashMap<Handle<Expression>, Handle<Expression>>>>,
+        already_imported: Rc<RefCell<IndexMap<Handle<Expression>, Handle<Expression>>>>,
         new_expressions: Rc<RefCell<Arena<Expression>>>,
     ) -> Block {
         macro_rules! map_expr {
@@ -388,7 +388,7 @@ impl<'a> DerivedModule<'a> {
         &mut self,
         h_expr: Handle<Expression>,
         old_expressions: &Arena<Expression>,
-        already_imported: Rc<RefCell<HashMap<Handle<Expression>, Handle<Expression>>>>,
+        already_imported: Rc<RefCell<IndexMap<Handle<Expression>, Handle<Expression>>>>,
         new_expressions: Rc<RefCell<Arena<Expression>>>,
         non_emitting_only: bool, // only brings items that should NOT be emitted into scope
         unique: bool,            // ensure expressions are unique with custom comparison
@@ -635,7 +635,7 @@ impl<'a> DerivedModule<'a> {
         });
 
         let expressions = Rc::new(RefCell::new(Arena::new()));
-        let expr_map = Rc::new(RefCell::new(HashMap::new()));
+        let expr_map = Rc::new(RefCell::new(IndexMap::new()));
 
         let mut local_variables = Arena::new();
         for (h_l, l) in func.local_variables.iter() {


### PR DESCRIPTION
fix OS-level shader caching by switching to `IndexMap` to maintain naga's deterministic output.