### PR TITLE
Add a failing test case for comments

### DIFF
--- a/src/compose/comment_strip_iter.rs
+++ b/src/compose/comment_strip_iter.rs
@@ -89,6 +89,67 @@ impl<'a> CommentReplaceExt<'a> for Lines<'a> {
 }
 
 #[test]
+fn multiline_comment_test() {
+    let test_cases = [
+        (
+            // Basic test
+            r"/*
+hoho
+*/",
+            r"  
+    
+  ",
+        ),
+        (
+            // Testing the commenting-out of multiline comments
+            r"///*
+hehe
+//*/",
+            r"    
+hehe
+    ",
+        ),
+        (
+            // Testing the commenting-out of single-line comments
+            r"/* // */ code goes here /*
+Still a comment // */
+/* dummy */",
+            r"         code goes here   
+                     
+           ",
+        ),
+        (
+            // A comment with a nested multiline comment
+            // Notice how the "//" inside the multiline comment doesn't take effect
+            r"/*
+//*
+*/commented
+*/not commented",
+            r"  
+   
+           
+  not commented",
+        ),
+    ];
+
+    for &(input, expected) in test_cases.iter() {
+        for (output_line, expected_line) in input.lines().replace_comments().zip(expected.lines()) {
+            assert_eq!(output_line.as_ref(), expected_line);
+        }
+    }
+}
+
+#[test]
+fn test_comment_becomes_spaces() {
+    let test_cases = [("let a/**/b =3u;", "let a    b =3u;")];
+    for &(input, expected) in test_cases.iter() {
+        for (output_line, expected_line) in input.lines().replace_comments().zip(expected.lines()) {
+            assert_eq!(output_line.as_ref(), expected_line);
+        }
+    }
+}
+
+#[test]
 fn comment_test() {
     const INPUT: &str = r"
 not commented


### PR DESCRIPTION
To prepare for me looking closer into https://github.com/bevyengine/naga_oil/issues/83 , I wanted to make sure that I understand some of the parsing edge cases.

While doing so, I actually did find a case that the current parser appears to not handle correctly. The case is
```rust
// A comment with a nested multiline comment
// Notice how the "//" inside the multiline comment doesn't take effect
            r"/*
//*
*/commented
*/not commented",
```

The parser currently goes 
1. `/*` starts a multiline comment. Increase the `block_depth`
2. The next line has one token, namely `//`. Ignore that. <=== This is where the error happens. Actually, that's not a `//` token, instead it's a nested `/*` token
3. The next line has a `*/` token. Decrease the `block_depth` back to zero. Then output `commented`, since it's no longer inside a multiline comment
4. The next line has a `*/` token. Decrease the `block_depth` again. This should be a parsing error, but we'll silently ignore it. Output `not commented`.

I see two ways of fixing this
- Introduce a separate regex for parsing inside a multiline comment.
- Wildly change the architecture to use `nom` (or another crate like winnow) for parsing tasks, since my experience is that using them for parsing leads to fewer subtle bugs. 