### PR TITLE
Report missing import error

### DIFF
--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -1346,7 +1346,7 @@ impl Composer {
                 }
                 Err(e) => {
                     self.module_sets.insert(set_key, module_set);
-                    return Err(e.into());
+                    return Err(e);
                 }
             }
         }

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -1324,7 +1324,7 @@ impl Composer {
             imports,
         } = self
             .preprocessor
-            .preprocess(&module_set.sanitized_source, shader_defs, self.validate)
+            .preprocess(&module_set.sanitized_source, shader_defs)
             .map_err(|inner| {
                 EnsureImportsError::from(ComposerError {
                     inner,
@@ -1636,12 +1636,9 @@ impl Composer {
 
         let name = name.unwrap_or_default();
 
-        let PreprocessOutput {
-            preprocessed_source,
-            imports,
-        } = self
+        let PreprocessOutput { imports, .. } = self
             .preprocessor
-            .preprocess(&sanitized_source, &shader_defs, self.validate)
+            .preprocess(&sanitized_source, &shader_defs)
             .map_err(|inner| ComposerError {
                 inner,
                 source: ErrSource::Constructing {

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -1094,6 +1094,74 @@ mod test {
         output_eq!(wgsl, "tests/expected/conditional_import_b.txt");
     }
 
+    #[test]
+    fn conditional_missing_import() {
+        let mut composer = Composer::default();
+
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/conditional_import_fail/mod_a_b.wgsl"),
+                file_path: "tests/conditional_import_fail/mod_a_b.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        let error = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/conditional_import_fail/top.wgsl"),
+                file_path: "tests/conditional_import_fail/top.wgsl",
+                ..Default::default()
+            })
+            .err()
+            .unwrap();
+
+        let text = error.emit_to_string(&composer);
+
+        // let mut f = std::fs::File::create("conditional_missing_import.txt").unwrap();
+        // f.write_all(text.as_bytes()).unwrap();
+        // drop(f);
+
+        output_eq!(text, "tests/expected/conditional_missing_import.txt");
+    }
+
+    #[test]
+    fn conditional_missing_import_nested() {
+        let mut composer = Composer::default();
+
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/conditional_import_fail/mod_a_b.wgsl"),
+                file_path: "tests/conditional_import_fail/mod_a_b.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        composer
+            .add_composable_module(ComposableModuleDescriptor {
+                source: include_str!("tests/conditional_import_fail/middle.wgsl"),
+                file_path: "tests/conditional_import_fail/middle.wgsl",
+                ..Default::default()
+            })
+            .unwrap();
+
+        let error = composer
+            .make_naga_module(NagaModuleDescriptor {
+                source: include_str!("tests/conditional_import_fail/top_nested.wgsl"),
+                file_path: "tests/conditional_import_fail/top_nested.wgsl",
+                ..Default::default()
+            })
+            .err()
+            .unwrap();
+
+        let text = error.emit_to_string(&composer);
+
+        // let mut f = std::fs::File::create("conditional_missing_import_nested.txt").unwrap();
+        // f.write_all(text.as_bytes()).unwrap();
+        // drop(f);
+
+        output_eq!(text, "tests/expected/conditional_missing_import_nested.txt");
+    }
+
     #[cfg(feature = "test_shader")]
     #[test]
     fn rusty_imports() {

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -1117,9 +1117,9 @@ mod test {
 
         let text = error.emit_to_string(&composer);
 
-        let mut f = std::fs::File::create("conditional_missing_import.txt").unwrap();
-        f.write_all(text.as_bytes()).unwrap();
-        drop(f);
+        // let mut f = std::fs::File::create("conditional_missing_import.txt").unwrap();
+        // f.write_all(text.as_bytes()).unwrap();
+        // drop(f);
 
         output_eq!(text, "tests/expected/conditional_missing_import.txt");
     }
@@ -1155,9 +1155,9 @@ mod test {
 
         let text = error.emit_to_string(&composer);
 
-        let mut f = std::fs::File::create("conditional_missing_import_nested.txt").unwrap();
-        f.write_all(text.as_bytes()).unwrap();
-        drop(f);
+        // let mut f = std::fs::File::create("conditional_missing_import_nested.txt").unwrap();
+        // f.write_all(text.as_bytes()).unwrap();
+        // drop(f);
 
         output_eq!(text, "tests/expected/conditional_missing_import_nested.txt");
     }

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -1117,9 +1117,9 @@ mod test {
 
         let text = error.emit_to_string(&composer);
 
-        // let mut f = std::fs::File::create("conditional_missing_import.txt").unwrap();
-        // f.write_all(text.as_bytes()).unwrap();
-        // drop(f);
+        let mut f = std::fs::File::create("conditional_missing_import.txt").unwrap();
+        f.write_all(text.as_bytes()).unwrap();
+        drop(f);
 
         output_eq!(text, "tests/expected/conditional_missing_import.txt");
     }
@@ -1155,9 +1155,9 @@ mod test {
 
         let text = error.emit_to_string(&composer);
 
-        // let mut f = std::fs::File::create("conditional_missing_import_nested.txt").unwrap();
-        // f.write_all(text.as_bytes()).unwrap();
-        // drop(f);
+        let mut f = std::fs::File::create("conditional_missing_import_nested.txt").unwrap();
+        f.write_all(text.as_bytes()).unwrap();
+        drop(f);
 
         output_eq!(text, "tests/expected/conditional_missing_import_nested.txt");
     }

--- a/src/compose/tests/conditional_import_fail/middle.wgsl
+++ b/src/compose/tests/conditional_import_fail/middle.wgsl
@@ -1,0 +1,9 @@
+#define_import_path middle
+
+#ifdef USE_A
+    #import a::b
+#endif
+
+fn mid_fn() -> u32 {
+    return b::C;
+}

--- a/src/compose/tests/conditional_import_fail/mod_a_b.wgsl
+++ b/src/compose/tests/conditional_import_fail/mod_a_b.wgsl
@@ -1,0 +1,3 @@
+#define_import_path a::b
+
+const C: u32 = 1u;

--- a/src/compose/tests/conditional_import_fail/top.wgsl
+++ b/src/compose/tests/conditional_import_fail/top.wgsl
@@ -1,0 +1,7 @@
+#ifdef USE_A
+    #import a::b
+#endif
+
+fn main() -> u32 {
+    return b::C;
+}

--- a/src/compose/tests/conditional_import_fail/top_nested.wgsl
+++ b/src/compose/tests/conditional_import_fail/top_nested.wgsl
@@ -1,0 +1,5 @@
+#import middle
+
+fn main() -> u32 {
+    return middle::mid_fn();
+}

--- a/src/compose/tests/expected/conditional_missing_import.txt
+++ b/src/compose/tests/expected/conditional_missing_import.txt
@@ -1,0 +1,8 @@
+error: required import 'b' not found
+  ┌─ tests/conditional_import_fail/top.wgsl:1:1
+  │
+1 │ #ifdef USE_A
+  │ ^
+  │
+  = missing import 'b'
+

--- a/src/compose/tests/expected/conditional_missing_import.txt
+++ b/src/compose/tests/expected/conditional_missing_import.txt
@@ -1,8 +1,8 @@
 error: required import 'b' not found
-  ┌─ tests/conditional_import_fail/top.wgsl:1:1
+  ┌─ tests/conditional_import_fail/top.wgsl:6:12
   │
-1 │ #ifdef USE_A
-  │ ^
+6 │     return b::C;
+  │            ^
   │
   = missing import 'b'
 

--- a/src/compose/tests/expected/conditional_missing_import_nested.txt
+++ b/src/compose/tests/expected/conditional_missing_import_nested.txt
@@ -1,0 +1,8 @@
+error: required import 'b' not found
+  ┌─ tests/conditional_import_fail/middle.wgsl:1:1
+  │
+1 │ #define_import_path middle
+  │ ^
+  │
+  = missing import 'b'
+

--- a/src/compose/tests/expected/conditional_missing_import_nested.txt
+++ b/src/compose/tests/expected/conditional_missing_import_nested.txt
@@ -1,7 +1,7 @@
 error: required import 'b' not found
-  ┌─ tests/conditional_import_fail/middle.wgsl:1:1
+  ┌─ tests/conditional_import_fail/top_nested.wgsl:1:1
   │
-1 │ #define_import_path middle
+1 │ #import middle
   │ ^
   │
   = missing import 'b'


### PR DESCRIPTION
# Objective

If an import is missing from the module it currently just unwraps and panics without any explanations.

# Solution

Don't unwrap and bubble up the error instead.

The error reporting is a bit weird because it just points at the start of the file and I'm not sure how to improve it.
