### PR TITLE
Replace unwrap in error handling

### DIFF
--- a/src/compose/error.rs
+++ b/src/compose/error.rs
@@ -197,7 +197,7 @@ impl ComposerError {
                     .map(|(span, desc)| {
                         trace!(
                             "mapping span {:?} -> {:?}",
-                            span.to_range().unwrap(),
+                            span.to_range().unwrap_or(0..0),
                             map_span(span.to_range().unwrap_or(0..0))
                         );
                         Label::primary((), map_span(span.to_range().unwrap_or(0..0)))
@@ -219,7 +219,8 @@ impl ComposerError {
             ComposerErrorInner::WgslParseError(e) => (
                 e.labels()
                     .map(|(range, msg)| {
-                        Label::primary((), map_span(range.to_range().unwrap())).with_message(msg)
+                        Label::primary((), map_span(range.to_range().unwrap_or(0..0)))
+                            .with_message(msg)
                     })
                     .collect(),
                 vec![e.message().to_owned()],


### PR DESCRIPTION
I ran accross a case where instead of a warning I got an unwrap in error handling. Two cases didn't seem to use `unwrap_or(0..0)` like all the others in this function. The errors will get slightly weird when it's missing but at least it won't cause crashes and the user has some idea of what is wrong