### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,16 @@ naga = { version = "24", features = ["wgsl-in", "wgsl-out"] }
 tracing = "0.1"
 regex = "1.8"
 regex-syntax = "0.8"
-thiserror = "1.0"
+thiserror = "2.0"
 codespan-reporting = "0.11"
 data-encoding = "2.3.2"
-bit-set = "0.5"
-rustc-hash = "1.1.0"
+bit-set = "0.8"
+rustc-hash = "1.1"
 unicode-ident = "1"
 once_cell = "1.17.0"
 indexmap = "2"
 
 [dev-dependencies]
 wgpu = { version = "24", features = ["naga-ir"] }
-futures-lite = "1"
+futures-lite = "2"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt"] }

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -1233,7 +1233,7 @@ impl Composer {
         for (h, ty) in source_ir.types.iter() {
             if let Some(name) = &ty.name {
                 if composable.owned_types.contains(name)
-                    && items.map_or(true, |items| items.contains(name))
+                    && items.is_none_or(|items| items.contains(name))
                 {
                     derived.import_type(&h);
                 }
@@ -1243,7 +1243,7 @@ impl Composer {
         for (h, c) in source_ir.constants.iter() {
             if let Some(name) = &c.name {
                 if composable.owned_constants.contains(name)
-                    && items.map_or(true, |items| items.contains(name))
+                    && items.is_none_or(|items| items.contains(name))
                 {
                     derived.import_const(&h);
                 }
@@ -1253,7 +1253,7 @@ impl Composer {
         for (h, po) in source_ir.overrides.iter() {
             if let Some(name) = &po.name {
                 if composable.owned_functions.contains(name)
-                    && items.map_or(true, |items| items.contains(name))
+                    && items.is_none_or(|items| items.contains(name))
                 {
                     derived.import_pipeline_override(&h);
                 }
@@ -1263,7 +1263,7 @@ impl Composer {
         for (h, v) in source_ir.global_variables.iter() {
             if let Some(name) = &v.name {
                 if composable.owned_vars.contains(name)
-                    && items.map_or(true, |items| items.contains(name))
+                    && items.is_none_or(|items| items.contains(name))
                 {
                     derived.import_global(&h);
                 }
@@ -1273,7 +1273,7 @@ impl Composer {
         for (h_f, f) in source_ir.functions.iter() {
             if let Some(name) = &f.name {
                 if composable.owned_functions.contains(name)
-                    && (items.map_or(true, |items| items.contains(name))
+                    && (items.is_none_or(|items| items.contains(name))
                         || composable
                             .override_functions
                             .values()


### PR DESCRIPTION
`rustc-hash` can't be updated for now because naga/wgpu is still on 1.1 and it's used in some public naga structs that we use https://github.com/gfx-rs/wgpu/issues/6999

Closes https://github.com/bevyengine/naga_oil/issues/114