### PR TITLE
Wgpu 25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "a crate for combining and manipulating shaders using naga IR"
 repository = "https://github.com/bevyengine/naga_oil/"
 readme = "README.md"
+rust-version = "1.82"
 
 [features]
 default = ["test_shader", "glsl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ prune = []
 allow_deprecated = []
 
 [dependencies]
-naga = { version = "24", features = ["wgsl-in", "wgsl-out"] }
+naga = { version = "25", features = ["wgsl-in", "wgsl-out"] }
 tracing = "0.1"
 regex = "1.8"
 regex-syntax = "0.8"
@@ -31,6 +31,6 @@ once_cell = "1.17.0"
 indexmap = "2"
 
 [dev-dependencies]
-wgpu = { version = "24", features = ["naga-ir"] }
+wgpu = { version = "25", features = ["naga-ir"] }
 futures-lite = "2"
 tracing-subscriber = { version = "0.3", features = ["std", "fmt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "a crate for combining and manipulating shaders using naga IR"
 repository = "https://github.com/bevyengine/naga_oil/"
 readme = "README.md"
-rust-version = "1.82"
+rust-version = "1.84"
 
 [features]
 default = ["test_shader", "glsl"]
@@ -23,7 +23,7 @@ tracing = "0.1"
 regex = "1.8"
 regex-syntax = "0.8"
 thiserror = "2.0"
-codespan-reporting = "0.11"
+codespan-reporting = "0.12"
 data-encoding = "2.3.2"
 bit-set = "0.8"
 rustc-hash = "1.1"

--- a/examples/pbr_compose_test.rs
+++ b/examples/pbr_compose_test.rs
@@ -145,11 +145,10 @@ fn test_wgsl_string_compile(n: usize) {
         .into_iter()
         .next()
         .unwrap();
-    let device = futures_lite::future::block_on(
-        adapter.request_device(&wgpu::DeviceDescriptor::default(), None),
-    )
-    .unwrap()
-    .0;
+    let device =
+        futures_lite::future::block_on(adapter.request_device(&wgpu::DeviceDescriptor::default()))
+            .unwrap()
+            .0;
 
     for _ in 0..n {
         let _desc = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -169,11 +168,10 @@ fn test_composer_compile(n: usize, composer: &mut Composer) {
         .into_iter()
         .next()
         .unwrap();
-    let device = futures_lite::future::block_on(
-        adapter.request_device(&wgpu::DeviceDescriptor::default(), None),
-    )
-    .unwrap()
-    .0;
+    let device =
+        futures_lite::future::block_on(adapter.request_device(&wgpu::DeviceDescriptor::default()))
+            .unwrap()
+            .0;
 
     for _ in 0..n {
         let module = composer

--- a/src/compose/comment_strip_iter.rs
+++ b/src/compose/comment_strip_iter.rs
@@ -51,7 +51,7 @@ impl<'a> Iterator for CommentReplaceIter<'a> {
                 .unwrap_or(line_in.len());
 
             if let CommentState::Block(_) = self.state {
-                output.extend(std::iter::repeat(' ').take(section_end - section_start));
+                output.extend(std::iter::repeat_n(' ', section_end - section_start));
             } else {
                 output.push_str(&line_in[section_start..section_end]);
             }
@@ -62,10 +62,10 @@ impl<'a> Iterator for CommentReplaceIter<'a> {
                     match marker.as_str() {
                         // only possible in None state
                         "//" => {
-                            output.extend(
-                                std::iter::repeat(' ')
-                                    .take(line_in.len() - marker.start() - section_start),
-                            );
+                            output.extend(std::iter::repeat_n(
+                                ' ',
+                                line_in.len() - marker.start() - section_start,
+                            ));
                             return Some(Cow::Owned(output));
                         }
                         // only possible in None or Block state

--- a/src/compose/preprocess.rs
+++ b/src/compose/preprocess.rs
@@ -267,7 +267,7 @@ impl Preprocessor {
 
                     loop {
                         // output spaces for removed lines to keep spans consistent (errors report against substituted_source, which is not preprocessed)
-                        final_string.extend(std::iter::repeat(" ").take(line.len()));
+                        final_string.extend(std::iter::repeat_n(" ", line.len()));
                         offset += line.len() + 1;
 
                         // PERF: Ideally we don't do multiple `match_indices` passes over `line`
@@ -351,7 +351,7 @@ impl Preprocessor {
 
                     final_string.push_str(&item_replaced_line);
                     let diff = line.len().saturating_sub(item_replaced_line.len());
-                    final_string.extend(std::iter::repeat(" ").take(diff));
+                    final_string.extend(std::iter::repeat_n(" ", diff));
                     offset += original_line.len() + 1;
                     output = true;
                 }
@@ -359,7 +359,7 @@ impl Preprocessor {
 
             if !output {
                 // output spaces for removed lines to keep spans consistent (errors report against substituted_source, which is not preprocessed)
-                final_string.extend(std::iter::repeat(" ").take(line.len()));
+                final_string.extend(std::iter::repeat_n(" ", line.len()));
                 offset += line.len() + 1;
             }
             final_string.push('\n');

--- a/src/compose/test.rs
+++ b/src/compose/test.rs
@@ -1401,14 +1401,12 @@ mod test {
             .into_iter()
             .next()
             .unwrap();
-        let (device, queue) = futures_lite::future::block_on(adapter.request_device(
-            &wgpu::DeviceDescriptor {
+        let (device, queue) =
+            futures_lite::future::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
                 required_features: Features::MAPPABLE_PRIMARY_BUFFERS,
                 ..Default::default()
-            },
-            None,
-        ))
-        .unwrap();
+            }))
+            .unwrap();
 
         let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             source: wgpu::ShaderSource::Naga(Cow::Owned(module)),
@@ -1477,7 +1475,11 @@ mod test {
 
         queue.submit([buffer]);
 
-        while !device.poll(wgpu::MaintainBase::Wait).is_queue_empty() {
+        while !device
+            .poll(wgpu::MaintainBase::Wait)
+            .unwrap()
+            .is_queue_empty()
+        {
             println!("waiting...");
         }
 
@@ -1485,7 +1487,11 @@ mod test {
             .slice(..)
             .map_async(wgpu::MapMode::Read, |_| ());
 
-        while !device.poll(wgpu::MaintainBase::Wait).is_queue_empty() {
+        while !device
+            .poll(wgpu::MaintainBase::Wait)
+            .unwrap()
+            .is_queue_empty()
+        {
             println!("waiting...");
         }
 

--- a/src/compose/tests/expected/err_validation_1.txt
+++ b/src/compose/tests/expected/err_validation_1.txt
@@ -3,8 +3,8 @@ error: failed to build a valid final module: Function [1] 'func' is invalid
   │  
 7 │ ╭ fn func() -> f32 {
 8 │ │     return 1u;
-  │ │            ^^ naga::Expression [0]
-  │ ╰──────────────^ naga::Function [1]
+  │ │            ^^ naga::ir::Expression [0]
+  │ ╰──────────────^ naga::ir::Function [1]
   │  
   = The `return` value Some([0]) does not match the function return value
 

--- a/src/compose/tests/expected/err_validation_2.txt
+++ b/src/compose/tests/expected/err_validation_2.txt
@@ -3,8 +3,8 @@ error: failed to build a valid final module: Function [0] 'valid_inc::func' is i
   │  
 7 │ ╭ fn func() -> f32 {
 8 │ │     return 1u;
-  │ │            ^^ naga::Expression [0]
-  │ ╰──────────────^ naga::Function [0]
+  │ │            ^^ naga::ir::Expression [0]
+  │ ╰──────────────^ naga::ir::Function [0]
   │  
   = The `return` value Some([0]) does not match the function return value
 

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -92,8 +92,8 @@ impl<'a> DerivedModule<'a> {
                     | TypeInner::Image { .. }
                     | TypeInner::Sampler { .. }
                     | TypeInner::Atomic { .. }
-                    | TypeInner::AccelerationStructure
-                    | TypeInner::RayQuery => ty.inner.clone(),
+                    | TypeInner::AccelerationStructure { .. }
+                    | TypeInner::RayQuery { .. } => ty.inner.clone(),
 
                     TypeInner::Pointer { base, space } => TypeInner::Pointer {
                         base: self.import_type(base),
@@ -407,6 +407,14 @@ impl<'a> DerivedModule<'a> {
                                 }
                             }
                             naga::RayQueryFunction::Terminate => naga::RayQueryFunction::Terminate,
+                            naga::RayQueryFunction::GenerateIntersection { hit_t } => {
+                                naga::RayQueryFunction::GenerateIntersection {
+                                    hit_t: map_expr!(hit_t),
+                                }
+                            }
+                            naga::RayQueryFunction::ConfirmIntersection => {
+                                naga::RayQueryFunction::ConfirmIntersection
+                            }
                         },
                     },
                     Statement::SubgroupBallot { result, predicate } => Statement::SubgroupBallot {
@@ -690,6 +698,12 @@ impl<'a> DerivedModule<'a> {
             Expression::RayQueryProceedResult => expr.clone(),
             Expression::RayQueryGetIntersection { query, committed } => {
                 Expression::RayQueryGetIntersection {
+                    query: map_expr!(query),
+                    committed: *committed,
+                }
+            }
+            Expression::RayQueryVertexPositions { query, committed } => {
+                Expression::RayQueryVertexPositions {
                     query: map_expr!(query),
                     committed: *committed,
                 }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -172,7 +172,7 @@ impl<'a> DerivedModule<'a> {
             let new_global = GlobalVariable {
                 name: gv.name.clone(),
                 space: gv.space,
-                binding: gv.binding.clone(),
+                binding: gv.binding,
                 ty: self.import_type(&gv.ty),
                 init: gv.init.map(|c| self.import_global_expression(c)),
             };


### PR DESCRIPTION
Bog standard wgpu upgrade. Tests pass and clippy is happy.

Clippy recommended `std::iter::repeat_n(...)` instead of `std::iter::repeat(...).take(...)`, which requires rust 1.82 so I added an msrv of ~~1.82~~ to `Cargo.toml`.

edit: Bumped msrv to 1.84 to match wgpu 25's.