### PR TITLE
Fix attempt to import offset as const.

### DIFF
--- a/src/derive.rs
+++ b/src/derive.rs
@@ -572,7 +572,7 @@ impl<'a> DerivedModule<'a> {
                 gather: *gather,
                 coordinate: map_expr!(coordinate),
                 array_index: map_expr_opt!(array_index),
-                offset: offset.map(|c| self.import_global_expression(c)),
+                offset: map_expr_opt!(offset),
                 level: match level {
                     SampleLevel::Auto | SampleLevel::Zero => *level,
                     SampleLevel::Exact(expr) => SampleLevel::Exact(map_expr!(expr)),


### PR DESCRIPTION
For some reason wgpu-25 becomes very grumpy with this otherwise:

```sh
called `Result::unwrap()` on an `Err` value: BadHandle { kind: "naga::ir::Expression", index: 16 }
```