### PR TITLE
Dependency cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,11 @@ allow_deprecated = []
 naga = { version = "26", features = ["wgsl-in", "wgsl-out", "termcolor"] }
 tracing = "0.1"
 regex = "1.8"
-regex-syntax = "0.8"
 thiserror = "2.0"
 codespan-reporting = "0.12"
 data-encoding = "2.3.2"
-bit-set = "0.8"
 rustc-hash = "1.1"
 unicode-ident = "1"
-once_cell = "1.17.0"
 indexmap = "2"
 
 [dev-dependencies]

--- a/src/compose/comment_strip_iter.rs
+++ b/src/compose/comment_strip_iter.rs
@@ -1,16 +1,14 @@
 use std::{borrow::Cow, str::Lines};
 
 use regex::Regex;
+use std::sync::LazyLock;
 
 // outside of blocks and quotes, change state on //, /* or "
-static RE_NONE: once_cell::sync::Lazy<Regex> =
-    once_cell::sync::Lazy::new(|| Regex::new(r#"(//|/\*|\")"#).unwrap());
+static RE_NONE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(//|/\*|\")"#).unwrap());
 // in blocks, change on /* and */
-static RE_BLOCK: once_cell::sync::Lazy<Regex> =
-    once_cell::sync::Lazy::new(|| Regex::new(r"(/\*|\*/)").unwrap());
+static RE_BLOCK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(/\*|\*/)").unwrap());
 // in quotes, change only on "
-static RE_QUOTE: once_cell::sync::Lazy<Regex> =
-    once_cell::sync::Lazy::new(|| Regex::new(r#"\""#).unwrap());
+static RE_QUOTE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"\""#).unwrap());
 
 #[derive(PartialEq, Eq)]
 enum CommentState {

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -130,6 +130,7 @@ use indexmap::IndexMap;
 use naga::EntryPoint;
 use regex::Regex;
 use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
+use std::sync::LazyLock;
 use tracing::{debug, trace};
 
 use crate::{
@@ -348,8 +349,8 @@ impl Default for Composer {
             check_decoration_regex: Regex::new(
                 format!(
                     "({}|{})",
-                    regex_syntax::escape(DECORATION_PRE),
-                    regex_syntax::escape(DECORATION_OVERRIDE_PRE)
+                    regex::escape(DECORATION_PRE),
+                    regex::escape(DECORATION_OVERRIDE_PRE)
                 )
                 .as_str(),
             )
@@ -357,8 +358,8 @@ impl Default for Composer {
             undecorate_regex: Regex::new(
                 format!(
                     r"(\x1B\[\d+\w)?([\w\d_]+){}([A-Z0-9]*){}",
-                    regex_syntax::escape(DECORATION_PRE),
-                    regex_syntax::escape(DECORATION_POST)
+                    regex::escape(DECORATION_PRE),
+                    regex::escape(DECORATION_POST)
                 )
                 .as_str(),
             )
@@ -370,8 +371,8 @@ impl Default for Composer {
             override_fn_regex: Regex::new(
                 format!(
                     r"(override\s+fn\s+)([^\s]+){}([\w\d]+){}(\s*)\(",
-                    regex_syntax::escape(DECORATION_PRE),
-                    regex_syntax::escape(DECORATION_POST)
+                    regex::escape(DECORATION_PRE),
+                    regex::escape(DECORATION_POST)
                 )
                 .as_str(),
             )
@@ -379,8 +380,8 @@ impl Default for Composer {
             undecorate_override_regex: Regex::new(
                 format!(
                     "{}([A-Z0-9]*){}",
-                    regex_syntax::escape(DECORATION_OVERRIDE_PRE),
-                    regex_syntax::escape(DECORATION_POST)
+                    regex::escape(DECORATION_OVERRIDE_PRE),
+                    regex::escape(DECORATION_POST)
                 )
                 .as_str(),
             )
@@ -1927,8 +1928,7 @@ impl Composer {
     }
 }
 
-static PREPROCESSOR: once_cell::sync::Lazy<Preprocessor> =
-    once_cell::sync::Lazy::new(Preprocessor::default);
+static PREPROCESSOR: LazyLock<Preprocessor> = LazyLock::new(Preprocessor::default);
 
 /// Get module name and all required imports (ignoring shader_defs) from a shader string
 pub fn get_preprocessor_data(


### PR DESCRIPTION
There are a few dependencies that are no longer necessary due to the MSRV at 1.84. Also removed the `regex-syntax` dependency since this crate already pulls in the entire `regex` crate.