### PR TITLE
Emit override-redirected functions in deterministic order

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,5 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
+use indexmap::IndexMap;
 use naga::{Block, Expression, Function, Handle, Module, Statement};
 use thiserror::Error;
 
@@ -183,8 +184,9 @@ impl Redirector {
     }
 
     pub fn into_module(self) -> Result<naga::Module, RedirectError> {
-        // reorder functions so that dependents come first
-        let mut requirements: HashMap<_, _> = self
+        // reorder functions so that dependents come first. IndexMap (not HashMap)
+        // so the emission order is deterministic across runs.
+        let mut requirements: IndexMap<_, _> = self
             .module
             .functions
             .iter()


### PR DESCRIPTION
## Problem

`Redirector::into_module` topologically sorts functions so dependents are emitted before their callers, but it drives the emission order by iterating a `HashMap`. That order is valid but arbitrary and reseeds every process, so a module that uses a function `override` (the redirector only runs when an override is present) composes to **byte-different output on every run**. This breaks gpu-driver shader caching.

## Fix

Use an `IndexMap` so the `retain()` loop visits functions in the deterministic source-arena order; same-level functions then emit in a stable order. Behaviour is otherwise unchanged, this path is only reachable when a function override exists, and `indexmap` is already a dependency.